### PR TITLE
fix: add liquidity ratio

### DIFF
--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -711,6 +711,7 @@ export default {
             reserveDenoms.sort().join().toLowerCase() === baseDenoms.join().toLowerCase() ||
             poolIterator.reserve_coin_denoms.join().toLowerCase() === denoms.join().toLowerCase()
           ) {
+            state.poolBaseDenoms = reserveDenoms;
             pool.value = poolIterator;
             return;
           }


### PR DESCRIPTION
fix: https://github.com/allinbits/demeris/issues/422

some pool reserveBalaces order is not equal to assetANew?.base_denom > assetBNew?.base_denom logic
I mean when reserveBalances order is uxprt, uatom, in the add liquidity page coinA is uatom and coinB is uxprt 
so it causes the wrong ratio error