### PR TITLE
fix: add liquidity ratio

### DIFF
--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -521,12 +521,19 @@ export default {
       }
 
       if (reserveBalances.value?.length) {
+        const amountA =
+          form.coinA.asset.base_denom == state.poolBaseDenoms[0]
+            ? reserveBalances.value[0].amount
+            : reserveBalances.value[1].amount;
+        const amountB =
+          form.coinB.asset.base_denom == state.poolBaseDenoms[1]
+            ? reserveBalances.value[1].amount
+            : reserveBalances.value[0].amount;
+        const precisionB =
+          form.coinB.asset.base_denom == state.poolBaseDenoms[1] ? precisions.value.coinB : precisions.value.coinA;
         return {
           coinA,
-          coinB: new BigNumber(reserveBalances.value[1].amount)
-            .dividedBy(reserveBalances.value[0].amount)
-            .shiftedBy(precisions.value.coinB)
-            .toNumber(),
+          coinB: new BigNumber(amountB).dividedBy(amountA).shiftedBy(precisionB).toNumber(),
         };
       }
 
@@ -698,6 +705,8 @@ export default {
 
         for (const poolIterator of pools.value) {
           const reserveDenoms = await getReserveBaseDenoms(poolIterator);
+          // original order is changed after below if statement ex) ["uxprt", "uatom"] => ["uatom" , "uxprt"]
+          state.poolBaseDenoms = JSON.parse(JSON.stringify(reserveDenoms));
 
           if (
             reserveDenoms.sort().join().toLowerCase() === baseDenoms.join().toLowerCase() ||
@@ -909,7 +918,7 @@ export default {
             const precisionA = store.getters['demeris/getDenomPrecision']({ name: form.coinA.asset.base_denom }) || 6;
             const amountA = parseCoins(form.coinA.asset.amount)[0].amount || 0;
             const feeA = feesAmount.value[form.coinA.asset.base_denom] || 0;
-            
+
             const precisionB = store.getters['demeris/getDenomPrecision']({ name: form.coinB.asset.base_denom }) || 6;
             const amountB = parseCoins(form.coinB.asset.amount)[0].amount || 0;
             const feeB = feesAmount.value[form.coinB.asset.base_denom] || 0;
@@ -919,11 +928,11 @@ export default {
             const bigAmountA = new BigNumber(amountA).minus(feeA);
             const bigAmountB = new BigNumber(amountB).minus(feeB);
             const amountsPositive = bigAmountA.isPositive() && bigAmountB.isPositive();
-            const bigAmountBToA = bigAmountB.dividedBy(bigExchangeAmount)
+            const bigAmountBToA = bigAmountB.dividedBy(bigExchangeAmount);
 
             const minAmount = BigNumber.minimum(bigAmountA, bigAmountBToA);
 
-            console.log("minamount", minAmount.toString());
+            console.log('minamount', minAmount.toString());
 
             if (minAmount.isEqualTo(bigAmountA) && amountsPositive) {
               form.coinA.amount = bigAmountA.shiftedBy(-precisionA).decimalPlaces(precisionA).toString();


### PR DESCRIPTION
fix: https://github.com/allinbits/demeris/issues/422
some pools have different reserveBalances order, compare to component's coinA and coinB
so, coinA = reserveBalances[0] is not guaranteed. fixed that part 😊
ex) 
pool xprt, atom
![스크린샷 2021-08-12 오전 3 16 03](https://user-images.githubusercontent.com/38318319/129081839-a350c756-b118-4936-b88b-2116cc7f55d4.png)

component atom, xprt
![스크린샷 2021-08-12 오전 3 16 41](https://user-images.githubusercontent.com/38318319/129081899-bbbe96fe-47ec-4b9f-b6eb-a8ddb374bc03.png)

