### PR TITLE
fix/terms opening in new tab

### DIFF
--- a/src/components/common/TxStepsModal.vue
+++ b/src/components/common/TxStepsModal.vue
@@ -70,8 +70,9 @@
           </div>
 
           <div class="max-w-md mx-auto -text-1 text-muted text-center leading-copy px-6">
-            Once executed, transactions cannot be reverted. By continuing, you agree to our
-            <a class="underline" href="https://emeris.com/terms" rel="noopener noreferrer">Terms of Service</a>.
+            {{ $t('components.txHandlingModal.noRevert') }}
+            <a class="underline" href="https://emeris.com/terms" target="_blank" rel="noopener noreferrer">{{ $t('components.settingsMenu.tos') }}.
+            </a>
           </div>
 
           <div class="py-6 max-w-sm mx-auto" :class="{ 'px-6': variant === 'widget' }">

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -168,6 +168,7 @@ export const messages = {
         addLiqActionFail: 'Add liquidity failed',
         withdrawLiqActionFail: 'Liquidity withdrawal failed',
         txFail: 'Transaction failed',
+        noRevert: 'Once executed, transactions cannot be reverted. By continuing, you agree to our',
       },
       swap: {
         title: 'Swap',


### PR DESCRIPTION
During TxStepsModal, there is a point when users are warned about how their transaction is not reversible, and to read the ToS. Right now the link to the ToS opens in the same tab as Emeris, breaking their current transaction. This is a tiny PR that fixes that by opening the ToS in a new tab.