### PR TITLE
fix: i18n wrong path for swapActionPartiallyComplete

### DIFF
--- a/src/components/common/TxHandlingModal.vue
+++ b/src/components/common/TxHandlingModal.vue
@@ -464,7 +464,7 @@ export default defineComponent({
                 break;
               case 'swap':
                 if (props.txResult.swappedPercent !== 100) {
-                  title.value = t('components.previews.transfer.swapActionPartiallyComplete', {
+                  title.value = t('components.txHandlingModal.swapActionPartiallyComplete', {
                     swappedPercent: parseInt(`${props.txResult.swappedPercent}`),
                   });
                 } else {


### PR DESCRIPTION
fix i18n title path for this modal
![image](https://user-images.githubusercontent.com/38318319/129604491-2de7a7ff-c63c-41db-ae0b-a33f15731e1e.png)
