### PR TITLE
fix/disable production purge of css

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: { content: ['./public/**/*.html'] },
+  purge: false,
   // mode: 'jit',
   darkMode: 'class', // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
From @nassdonald 
>  There’s some really weird stuff happening in the test deployment… are we tree shaking or something? It seems there’s a lot of stuff very different to my local develop build.
>  Icon.vue doesn’t seem to be rendering the inline style required to change the size of the icon (via font-size).
>  Classes and styles are breaking all over the place. Sometimes there’s [object Object] where there should be classes.
>  Some classes haven’t been generated at all, despite being defined in css to extend tailwind – again, working fine locally – like the dark:hover:text-inverse class used on step 1 of the Send flow.
>  Sometimes there’s commas between class names, which breaks styles – perhaps this is my bad for using an array for classes? :class="[condition ? 'true-class' : 'false-class', anotherCondition ? 'foo' : 'bar']" It’s weird because this works fine locally… :confused:

Tailwind purge docs states that `That means that it is important to avoid dynamically creating class strings in your templates with string concatenation, otherwise PurgeCSS won't know to preserve those classes.` We don't have time to update all the Vue files to remove dynamically created class strings, so this is is a fix for launch tomorrow.