### PR TITLE
fix/hide staking apy

### DIFF
--- a/src/components/common/StakeTable.vue
+++ b/src/components/common/StakeTable.vue
@@ -45,7 +45,6 @@ export default defineComponent({
           <h3 class="text-1 font-bold">{{ $t('components.stakeTable.earnRewards') }} <Ticker :name="denom" /></h3>
           <p class="text-muted leading-copy mt-3">
             {{ $t('components.stakeTable.lockUp') }} <Ticker :name="denom" /> {{ $t('components.stakeTable.andEarn') }}
-            <span class="font-bold">{{ $t('components.stakeTable.apy') }}</span>.
           </p>
         </div>
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -154,7 +154,7 @@ export const messages = {
       stakeTable: {
         earnRewards: 'Earn rewards by staking',
         lockUp: 'Lock up your',
-        andEarn: 'and earn staking rewards with an average',
+        andEarn: 'and earn continuous staking rewards.',
         apy: '9.7% APY',
       },
       feeWarningModal: {


### PR DESCRIPTION
Staking APY was hardcoded to 9.7% even though it isn't for most chains. Hiding it for now until we get a real source for this