### PR TITLE
fix: Add watcher instead of replacing ref

### DIFF
--- a/src/components/common/Denom.vue
+++ b/src/components/common/Denom.vue
@@ -20,7 +20,13 @@ export default defineComponent({
       (denomName, oldDenomName) => {
         if (denomName != oldDenomName || !loaded) {
           const { displayName } = useDenom(denomName);
-          display = displayName;
+          watch(
+            () => displayName.value,
+            (newName) => {
+              display.value = newName;
+            },
+            { immediate: true },
+          );
         }
       },
       { immediate: true },

--- a/src/components/common/Ticker.vue
+++ b/src/components/common/Ticker.vue
@@ -20,7 +20,13 @@ export default defineComponent({
       (denomName, oldDenomName) => {
         if (denomName != oldDenomName || !loaded) {
           const { tickerName } = useDenom(denomName);
-          ticker = tickerName;
+          watch(
+            () => tickerName.value,
+            (newName) => {
+              ticker.value = newName;
+            },
+            { immediate: true },
+          );
         }
       },
       { immediate: true },


### PR DESCRIPTION
Seems that Vue loses reactivity if a ref is completely replaced by a new ref. This change keeps existing ref and adds a watcher to update.

Fixes: https://github.com/allinbits/demeris/issues/535