### PR TITLE
fix: offer coin fee

### DIFF
--- a/src/utils/actionHandler.ts
+++ b/src/utils/actionHandler.ts
@@ -1065,7 +1065,6 @@ export async function msgFromStepTransaction(
       if (a.denom > b.denom) return 1;
       return 0;
     });
-    console.log(isReverse, slippage);
     const msg = await store.dispatch('tendermint.liquidity.v1beta1/MsgSwapWithinBatch', {
       value: MsgSwapWithinBatch.fromPartial({
         swapRequesterAddress: await getOwnAddress({ chain_name }), // TODO: change to liq module chain


### PR DESCRIPTION
for now, if we send offerCoinFee as '0'
at backend below code works for us to autofill the offerCoinFee but there is a attack vector with this(backend-level)😅
`
if msg.OfferCoinFee.IsZero() {
  msg.OfferCoinFee = types.GetOfferCoinFee(msg.OfferCoin, params.SwapFeeRate)
 }
`


currently min swap amount is 100 baseAsset (ex: 100uatom)
if we try to swap 100 uatom , offer coin fee(100 * 0.0015) will be 0(0.15 truncated)
So, attackers can do some kind of spamming without offerCoinFee
in next gaia update, this will be ceil() not trunc() So, minimum fee will be 1

https://github.com/tendermint/liquidity/pull/436/files#diff-fe3b27b6d5aadc7562d42d7932b196afe73098fc4cd5f9998799f40751178803R100
see more: https://github.com/tendermint/liquidity/issues/435

after gaia update,
0 amount will not work and we have to change trunc() to ceil() too...
https://github.com/tendermint/liquidity/pull/436/files#diff-fb569275cefed7f8022baf3eb38b4861001e7f0a016667e311830ea3a0ff7bbaR141

this PR is just for clarification now (Keplr Msg will show a real offerCoinFee amount instead of 0)