### PR TITLE
fix: open asset base denom in pool page

### DIFF
--- a/src/views/Pool.vue
+++ b/src/views/Pool.vue
@@ -329,7 +329,7 @@ export default defineComponent({
     });
 
     const openAssetPage = (asset: Record<string, string>) => {
-      router.push({ name: 'Asset', params: { denom: asset.denom } });
+      router.push({ name: 'Asset', params: { denom: asset.base_denom } });
     };
 
     watch(reserveBalances, updateDenoms, { immediate: true });


### PR DESCRIPTION
Use `base_denom` to open the Asset page from the 'Underlying assets' section of the pool detail.