### PR TITLE
fix: Switch no pool behavior

### DIFF
--- a/src/components/liquidity/Swap.vue
+++ b/src/components/liquidity/Swap.vue
@@ -931,9 +931,10 @@ export default defineComponent({
         assetsToReceive.value.find((asset) => {
           return asset?.base_denom === originPayCoinData?.base_denom;
         }) ?? originPayCoinData;
+
+      // reset amount, TODO: apply setCounterPairCoinAmount('');
       data.payCoinAmount = null;
       data.receiveCoinAmount = null;
-      // setCounterPairCoinAmount('');
     }
 
     function setMax() {


### PR DESCRIPTION
![스크린샷 2021-09-03 오전 3 09 44](https://user-images.githubusercontent.com/38318319/131895102-03b656ce-5bb6-48b9-a780-54488ffcc15a.png)

in this situation(no pool), if click the switch button.
the receive coin section is changed to empty state. it should be the pay coin.
so this pr fixed this issue : )