### PR TITLE
fix: stop loop if ticket transaction times out

### DIFF
--- a/src/store/demeris/actions.ts
+++ b/src/store/demeris/actions.ts
@@ -760,11 +760,11 @@ export const actions: ActionTree<State, RootState> & Actions = {
       if (subscribe) {
         commit('SUBSCRIBE', { action: DemerisActionTypes.GET_TX_STATUS, payload: { params } });
       }
+      return response.data;
     } catch (e) {
       console.error(e);
       throw new SpVuexError('Demeris:GetTXStatus', 'Could not perform API query.');
     }
-    return 'pending';
   },
   async [DemerisActionTypes.GET_CHAINS]({ commit, getters }, { subscribe = false }) {
     try {


### PR DESCRIPTION
- The app goes into an infinite loop if the ticket reaches 5min just in transit.
- Stop subscribing to every transaction broadcasted, now only fetch while it's pending, stuck, or in transit.