### PR TITLE
fix: handle not found route

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,6 +69,10 @@ const routes: Array<RouteRecordRaw> = [
     path: '/styles',
     component: () => import('../views/Styles.vue'),
   },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: { name: 'Portfolio' },
+  },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
Fixes #617 

[Vue Router docs](https://next.router.vuejs.org/guide/essentials/dynamic-matching.html#catch-all-404-not-found-route)