### PR TITLE
fix default import of lodash imports

### DIFF
--- a/src/components/assets/AssetsTable/AssetsTable.vue
+++ b/src/components/assets/AssetsTable/AssetsTable.vue
@@ -149,8 +149,8 @@
 </template>
 
 <script lang="ts">
-import groupBy from 'lodash.groupby';
-import orderBy from 'lodash.orderby';
+import * as groupBy from 'lodash.groupby';
+import * as orderBy from 'lodash.orderby';
 import { computed, defineComponent, PropType, ref } from 'vue';
 import { useStore } from 'vuex';
 

--- a/src/components/common/CoinList.vue
+++ b/src/components/common/CoinList.vue
@@ -74,7 +74,7 @@
   </div>
 </template>
 <script lang="ts">
-import orderBy from 'lodash.orderby';
+import * as orderBy from 'lodash.orderby';
 import { computed, defineComponent } from 'vue';
 import { useStore } from 'vuex';
 

--- a/src/components/liquidity/PoolsTable.vue
+++ b/src/components/liquidity/PoolsTable.vue
@@ -65,7 +65,7 @@
 <script lang="ts">
 import { ref } from '@vue/reactivity';
 import { computed, PropType, watch } from '@vue/runtime-core';
-import orderBy from 'lodash.orderby';
+import * as orderBy from 'lodash.orderby';
 import { useRouter } from 'vue-router';
 
 import CircleSymbol from '@/components/common/CircleSymbol.vue';

--- a/src/components/transfer/SendForm/SendFormAmount.vue
+++ b/src/components/transfer/SendForm/SendFormAmount.vue
@@ -204,7 +204,7 @@
 <script lang="ts">
 import { bech32 } from 'bech32';
 import BigNumber from 'bignumber.js';
-import orderBy from 'lodash.orderby';
+import * as orderBy from 'lodash.orderby';
 import { computed, defineComponent, inject, onMounted, PropType, reactive, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';

--- a/src/composables/useAccount.ts
+++ b/src/composables/useAccount.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import orderBy from 'lodash.orderby';
+import * as orderBy from 'lodash.orderby';
 import { computed, Ref, ref, unref, watch } from 'vue';
 
 import { GlobalDemerisGetterTypes, TypedAPIStore } from '@/store';

--- a/src/views/Receive.vue
+++ b/src/views/Receive.vue
@@ -85,7 +85,7 @@
 <script lang="ts">
 import { reactive, toRefs } from '@vue/reactivity';
 import { computed, watch } from '@vue/runtime-core';
-import orderBy from 'lodash.orderby';
+import * as orderBy from 'lodash.orderby';
 import { useI18n } from 'vue-i18n';
 import { useMeta } from 'vue-meta';
 


### PR DESCRIPTION
The imports would not work with Typescript "esModuleInterop": false, which we need in the extension