### PR TITLE
fix: Ensures balances have loaded before render

### DIFF
--- a/src/components/assets/AssetChainsIndicator/AssetChains.vue
+++ b/src/components/assets/AssetChainsIndicator/AssetChains.vue
@@ -1,6 +1,11 @@
 <template>
   <tippy v-show="chainsCount > 1" class="block w-8 h-8 relative">
-    <CircleSymbol variant="chain" :chain-name="filteredBalances[0].on_chain" :glow="false" />
+    <CircleSymbol
+      v-if="filteredBalances.length > 0"
+      variant="chain"
+      :chain-name="filteredBalances[0].on_chain"
+      :glow="false"
+    />
     <div class="absolute inset-0.5 -text-1 font-normal z-10 flex items-center justify-center">
       <span>{{ chainsCount }}<template v-if="hasMoreChains">+</template></span>
     </div>


### PR DESCRIPTION
Computed filteredBalances is not available immediately leading to a broken render when rendering `CircleSymbol` inside `AssetChains.vue`

A simple v-if defers rendering until filteredBalances is populated.