### PR TITLE
ci:test-feature-flag TEST_SHOW_CONSOLE_LOG

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 VUE_APP_EMERIS_ENDPOINT=https://dev.demeris.io/v1
 VUE_APP_EMERIS_LIQUIDITY_ENDPOINT=https://dev.demeris.io/v1/liquidity
+#VUE_APP_FEATURE_TEST_SHOW_CONSOLE_LOG=true

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,0 +1,15 @@
+import getUrlParameter from './getUrlParameter';
+
+export function featureRunning(feature: string) {
+  const urlParam = getUrlParameter(feature);
+
+  if (parseInt(urlParam) === 1) {
+    return true;
+  } else if (parseInt(urlParam) === 0) {
+    return false;
+  } else if (process.env['VUE_APP_FEATURE_' + feature]) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/utils/getUrlParameter.ts
+++ b/src/utils/getUrlParameter.ts
@@ -1,0 +1,5 @@
+export default function getUrlParameter(param: string) {
+  const url = new URL(window.location.href);
+  const c = url.searchParams.get(param);
+  return c;
+}

--- a/src/views/Portfolio.vue
+++ b/src/views/Portfolio.vue
@@ -68,6 +68,7 @@ import useAccount from '@/composables/useAccount';
 import usePools from '@/composables/usePools';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { pageview } from '@/utils/analytics';
+import { featureRunning } from '@/utils/features';
 
 export default {
   name: 'Portfolio',
@@ -90,6 +91,10 @@ export default {
         title: t('navbar.portfolio'),
       })),
     );
+
+    if (featureRunning('TEST_SHOW_CONSOLE_LOG')) {
+      console.log('TEST_SHOW_CONSOLE_LOG is running');
+    }
 
     const router = useRouter();
     const { balances } = useAccount();


### PR DESCRIPTION
Messing around a bit with feature flags:

Enable feature flag with env variables:
VUE_APP_FEATURE_ is the prefix
Should be possible by adding to netlify, or in .env file:
VUE_APP_FEATURE_TEST_SHOW_CONSOLE_LOG=true

Or enable feature flag with URL param (always has priority):
https://app.emeris.com/?TEST_SHOW_CONSOLE_LOG=1