### PR TITLE
fix:hide unverified assets

### DIFF
--- a/src/views/Asset.vue
+++ b/src/views/Asset.vue
@@ -155,7 +155,7 @@
 <script lang="ts">
 import { computed, defineComponent, ref, watch } from 'vue';
 import { useMeta } from 'vue-meta';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 
 import PoolBanner from '@/components/assets/AssetsTable/PoolBanner.vue';
@@ -179,6 +179,7 @@ import { VerifiedDenoms } from '@/types/api';
 import { getDisplayName } from '@/utils/actionHandler';
 import { pageview } from '@/utils/analytics';
 import { generateDenomHash, parseCoins } from '@/utils/basic';
+import { featureRunning } from '@/utils/FeatureManager';
 
 export default defineComponent({
   name: 'Asset',
@@ -211,6 +212,7 @@ export default defineComponent({
     });
     const apistore = useStore() as TypedAPIStore;
     const route = useRoute();
+    const router = useRouter();
     const denom = computed(() => route.params.denom as string);
 
     pageview({ page_title: 'Asset: ' + route.params.denom, page_path: '/asset/' + route.params.denom });
@@ -221,6 +223,9 @@ export default defineComponent({
       const verifiedDenoms: VerifiedDenoms = apistore.getters[GlobalDemerisGetterTypes.API.getVerifiedDenoms] || [];
       return verifiedDenoms.find((item) => item.name === denom.value);
     });
+    if (featureRunning('HIDE_UNVERIFIED_ASSETS') && !assetConfig.value) {
+      router.push('/');
+    }
 
     const nativeAsset = computed(() => {
       return nativeBalances.value.find((item) => item.base_denom === denom.value);


### PR DESCRIPTION
Fixes https://github.com/allinbits/demeris/issues/819
 - redirect to the homepage when trying to access such a page - same behavior as 404
 - Feature name: HIDE_UNVERIFIED_ASSETS
 - test by adding: ?VUE_APP_FEATURE_HIDE_UNVERIFIED_ASSETS=1
for example to:

http://localhost:8080/asset/%22%3Cscript%3Ealert('test');?VUE_APP_FEATURE_HIDE_UNVERIFIED_ASSETS=0