### PR TITLE
Fix:689 Change z-index of settings overlay

### DIFF
--- a/src/components/common/SettingsModal.vue
+++ b/src/components/common/SettingsModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="settings-modal absolute right-0 bg-surface rounded-2xl w-full sm:w-72 z-30 shadow-panel">
+    <div class="settings-modal absolute right-0 bg-surface rounded-2xl w-full sm:w-72 z-40 shadow-panel">
       <!-- basic settings -->
       <div v-if="!isAdvancedSettingsOpen" class="settings-modal-basic">
         <div class="py-2">


### PR DESCRIPTION
Fix for issue [689](https://github.com/allinbits/demeris/issues/689) 

Changes z-index of settings menu so that it stays above swap component.