### PR TITLE
fix:fixing the wrong denom name which is shown in assets table

### DIFF
--- a/src/components/common/Denom.vue
+++ b/src/components/common/Denom.vue
@@ -2,9 +2,13 @@
   {{ display }}
 </template>
 <script lang="ts">
-import { defineComponent, ref, toRefs,watch } from 'vue';
+import { defineComponent, ref, toRefs, watch } from 'vue';
 
 import useDenoms from '@/composables/useDenoms';
+import { GlobalDemerisGetterTypes, TypedAPIStore } from '@/store';
+import { getDisplayName } from '@/utils/actionHandler';
+import { featureRunning } from '@/utils/FeatureManager';
+import { useStore } from '@/utils/useStore';
 
 export default defineComponent({
   name: 'Denom',
@@ -12,28 +16,47 @@ export default defineComponent({
     name: { type: String, required: true },
   },
   setup(props) {
-    let display = ref('-');
-    const loaded = false;
-    const { useDenom } = useDenoms();
-    const name = toRefs(props).name;
-    watch(
-      () => name.value,
-      (denomName, oldDenomName) => {
-        if (denomName != oldDenomName || !loaded) {
-          const { displayName } = useDenom(denomName);
-          watch(
-            () => displayName.value,
-            (newName) => {
-              display.value = newName;
-            },
-            { immediate: true },
-          );
-        }
-      },
-      { immediate: true },
-    );
+    if (featureRunning('FIX_WRONG_DENOM_NAME_ON_ASSET_PAGE')) {
+      const apistore = useStore() as TypedAPIStore;
+      const propName = toRefs(props).name;
+      let display = ref('-');
+      const updateDenom = async (denomName) => {
+        display.value = await getDisplayName(denomName, apistore.getters[GlobalDemerisGetterTypes.API.getDexChain]);
+      };
 
-    return { display };
+      watch(
+        propName,
+        (denomName) => {
+          updateDenom(denomName);
+        },
+        { immediate: true },
+      );
+
+      return { display };
+    } else {
+      let display = ref('-');
+      const loaded = false;
+      const { useDenom } = useDenoms();
+      const name = toRefs(props).name;
+      watch(
+        () => name.value,
+        (denomName, oldDenomName) => {
+          if (denomName != oldDenomName || !loaded) {
+            const { displayName } = useDenom(denomName);
+            watch(
+              () => displayName.value,
+              (newName) => {
+                display.value = newName;
+              },
+              { immediate: true },
+            );
+          }
+        },
+        { immediate: true },
+      );
+
+      return { display };
+    }
   },
 });
 </script>


### PR DESCRIPTION
I'm not happy with this fix, but at least it's solving the problem for the customer right now...

Feature param: VUE_APP_FEATURE_FIX_WRONG_DENOM_NAME_ON_ASSET_PAGE=1

I don't like the usage of 
`await getDisplayName(denomName, apistore.getters[GlobalDemerisGetterTypes.API.getDexChain]);`

I would've liked to use `useDenom(denomName)`, but that kept causing bugs and issues.
Therefore I want to push this out to get rid of the bug for customers, so we can debug it while not causing damage anymore.

Feature off:
https://develop--emeris-app.netlify.app/?VUE_APP_FEATURE_FIX_WRONG_DENOM_NAME_ON_ASSET_PAGE=0
(showing DSM instead of ATOM)
<img width="528" alt="image" src="https://user-images.githubusercontent.com/1449065/153386488-d357e262-d7f8-4dd5-a141-c978dbedb95f.png">


Feature on:
https://develop--emeris-app.netlify.app/?VUE_APP_FEATURE_FIX_WRONG_DENOM_NAME_ON_ASSET_PAGE=1
(showing ATOM properly)
<img width="511" alt="image" src="https://user-images.githubusercontent.com/1449065/153386606-861e11a7-c5b1-4bc2-a11c-826e718c91f5.png">
