### PR TITLE
fix/broken-user-dropdown-test

### DIFF
--- a/cypress/support/pages/user-dropdown.js
+++ b/cypress/support/pages/user-dropdown.js
@@ -31,8 +31,6 @@ export class UserDropdown {
   }
 
   userDropdownExpanded() {
-    return cy.get(
-      'div[class="settings-modal absolute right-0 bg-surface rounded-2xl w-full sm:w-72 z-30 shadow-panel"]',
-    );
+    return cy.get('.settings-modal');
   }
 }


### PR DESCRIPTION
this test was broken due to recent changes. Made it less specific

npx cypress run --spec cypress/integration/user-settings-dropdown.spec.js --headed --no-exit