### PR TITLE
fix/receive-subpage-test

### DIFF
--- a/cypress/support/pages/receive.js
+++ b/cypress/support/pages/receive.js
@@ -14,7 +14,7 @@ export class Receive {
     this.searchField().type(text);
   }
   searchField() {
-    return cy.get('div[class="relative flex cursor-text"]').find('input');
+    return cy.get('div[class="suffix relative flex cursor-text"]').find('input');
   }
 
   quitWithX() {


### PR DESCRIPTION
Fixes test receive-subpage.spec.js (which was rightfully so broken)
cypress/support/pages/receive.js