### PR TITLE
fix: set correct theme class for 'system'

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -19,14 +19,24 @@ export default function useTheme(props: Props = {}) {
   });
 
   const updateDocument = (add: string, remove: string) => {
+    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
     if (!props.updateOnChange) {
       return;
+    }
+
+    if (add === 'system') {
+      add = isDark ? 'dark' : 'light';
+      remove = isDark ? 'light' : 'dark';
+    } else if (remove === 'system') {
+      remove = add === 'dark' ? 'light' : 'dark';
     }
 
     document.documentElement.classList.add(add);
     document.documentElement.classList.remove(remove);
   };
 
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => updateDocument('system', ''));
   watch(theme, updateDocument, { immediate: true, flush: 'post' });
 
   return theme;


### PR DESCRIPTION
# Problem
Currently, when the user's theme preference is set to 'system', the class `system` is applied to the root element (`<html>`). This class isn't used in Tailwind for any theming, so it has no effect.

The majority of the UI still effectively switches between themes, because of the `prefers-color-scheme` media queries in our stylesheet. But there are many styles and classes that depend on the `light` and `dark` classes on the root element in order to display correctly – such as any `dark:*` class.

# Solution
Detecting `prefers-color-scheme` value in JS and applying the correct corresponding theme class whenever 'system' is used.

I'm no JS wizard, so please feel free to suggest more elegant ways of achieving this. 🙏 