### PR TITLE
fix/sentry-fix-tracing-origins

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ if (featureRunning('SENTRY')) {
     integrations: [
       new BrowserTracing({
         routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-        tracingOrigins: ['app.emeris.com'],
+        tracingOrigins: ['app.emeris.com', /^\//],
       }),
     ],
     // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Trying to figure out why Sentry doesn't work in prod. Not sure how this regex is supposed to help, but it's included in Sentry's Vue3 documentation, so simply trying it.