### PR TITLE
Test: adding retries to cypress tests because plenty is not in our control

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "baseUrl": "http://localhost:8080/",
   "modifyObstructiveCode": true,
   "experimentalSourceRewriting": true,
-  "video": false
+  "video": false,
+  "retries": 2
 }


### PR DESCRIPTION
Temporary measure because of flaky tests. The tests will retry twice. Hoping that this will disturb us less with the "Connect Keplr" issue