### PR TITLE
build/automated-e2e-test-every-half-hour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - develop
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0,30 * * * *'
 
 env:
   VUE_APP_EMERIS_MNEMONIC: ${{ secrets.VUE_APP_EMERIS_MNEMONIC }}
@@ -103,7 +103,7 @@ jobs:
       - name: Notify Slack
         if: |
           failure() &&
-          github.event.schedule == '*/15 * * * *'
+          github.event.schedule == '0,30 * * * *'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: emeris-frontend-github


### PR DESCRIPTION
## Description
Changing the e2e tests to automatically run every half hour because unfortunately we don't make it in time for the next one to start (we cancel concurrent actions... which means that if the previous one is still running, it cancels that one. If we want to run e2e tests more frequently, we either have to disable that, or make our tests run faster).

