### PR TITLE
fix/staking-only-unstake-if-more-than-zero

### DIFF
--- a/src/components/stake/UnstakeForm/UnstakeFormAmount.vue
+++ b/src/components/stake/UnstakeForm/UnstakeFormAmount.vue
@@ -114,7 +114,7 @@ export default defineComponent({
         .toString();
     });
     const isValid = computed(() => {
-      return parseFloat(remainingStake.value) >= 0;
+      return parseFloat(remainingStake.value) >= 0 && parseFloat(form.amount) > 0;
     });
     const goToReview = () => {
       emit('next');


### PR DESCRIPTION
## Description
This fix ensures the submit button in the unstaking form is only enabled if the unstake amount is higher than 0.

Fixes https://github.com/EmerisHQ/demeris/issues/1246

## Testing
1. Ensure you have some staked tokens
2. When you go to the unstaking form, fill in nothing, or 0, and the button should be disabled
