### PR TITLE
prevent claiming < 1uatom

### DIFF
--- a/src/components/common/StakeTable.vue
+++ b/src/components/common/StakeTable.vue
@@ -44,7 +44,7 @@
           <tbody>
             <!-- claim rewards -->
             <tr
-              v-if="totalRewardsAmount"
+              v-if="totalRewardsAmount && totalRewardsAmount > 1"
               class="group cursor-pointer shadow-card hover:shadow-dropdown transition-shadow rounded-xl"
               @click="goStakeActionPage(StakingActions.CLAIM)"
             >


### PR DESCRIPTION
## Description

For context: https://allinbits.slack.com/archives/C02TBMVAJDN/p1646651857316049
less than 1uatom causes parseCoins to throw error.

Fixes: #1250 

## Feature flags

VUE_APP_FEATURE_STAKING=true&VUE_APP_FEATURE_TRANSACTIONS_CENTER=true

## Testing
1. Stake atom to a validator if not already staking.
2. Check if "claim rewards" shows up for amounts < 1uatom under the staking tab.

---
