### PR TITLE
fix: use floor() in staked balances

### DIFF
--- a/src/components/common/StakeTable.vue
+++ b/src/components/common/StakeTable.vue
@@ -286,7 +286,7 @@ export default defineComponent({
     const stakingBalances = computed(() => {
       return stakingBalancesByChain(
         store.getters[GlobalDemerisGetterTypes.API.getChainNameByBaseDenom]({ denom: propsRef.denom.value }),
-      );
+      ).filter((x) => Math.floor(parseFloat(x.amount)) > 0);
     });
     const getTimeToString = (isodate: string) => {
       return dayjs().to(dayjs(isodate));

--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -146,7 +146,7 @@ export default defineComponent({
           const stakedValidator = stakingBalances.value.find(
             (stakedVali) => stakedVali.validator_address === keyHashfromAddress(vali.operator_address),
           );
-          if (stakedValidator) {
+          if (stakedValidator && Math.floor(parseFloat(stakedValidator.amount)) > 0) {
             validators.push({ ...vali, stakedAmount: parseInt(stakedValidator.amount) });
           } else {
             validators.push({ ...vali, stakedAmount: 0 });


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue(s) is/are fixed.

Fixes: #1263 
Fixes: #1178

## Feature flags

VUE_APP_FEATURE_STAKING=true
VUE_APP_FEATURE_TRANSACTIONS_CENTER=true

## Testing

Ensure accurate display of staked balances. Dust & sub 1 basedenom (e.g. <1uatom) staked balances should not show

---

## Reviews (Optional)

@nassdonald , @fl-y 
