### PR TITLE
fix: 'receive average' -> 'receive over' for staking yields

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -19,7 +19,7 @@ export const messages = {
     components: {
       stakingBanner: {
         title: 'Stake',
-        text: 'Stake with a validator to receive an average',
+        text: 'Stake with a validator to receive over',
         textAPR: 'APR',
         cta: 'Start staking',
       },


### PR DESCRIPTION
## Description
Literal word switch in en.js

Fixes: #1274 

## Feature flags

VUE_APP_FEATURE_STAKING=1

## Testing
'receive over {inflation}% APR' in staking banner