### PR TITLE
fix: ibc channel error on ibc transfer with memo

### DIFF
--- a/src/actionhandler/actions/memoTransfer.ts
+++ b/src/actionhandler/actions/memoTransfer.ts
@@ -67,11 +67,25 @@ export async function memoTransfer({
             through: primaryChannel,
           },
         });
+
+        const counterpartyChannel =
+          apistore.getters[GlobalDemerisGetterTypes.API.getPrimaryChannel]({
+            chain_name: destination_chain_name,
+            destination_chain_name: chain_name,
+          }) ??
+          (await apistore.dispatch(
+            GlobalDemerisActionTypes.API.GET_PRIMARY_CHANNEL,
+            {
+              subscribe: true,
+              params: { chain_name: destination_chain_name, destination_chain_name: chain_name },
+            },
+            { root: true },
+          ));
         result.steps.push({
           name: 'transfer',
           status: 'pending',
           data: {
-            amount: { amount: amount.amount, denom: generateDenomHash(primaryChannel, amount.denom) },
+            amount: { amount: amount.amount, denom: generateDenomHash(counterpartyChannel, amount.denom) },
             chain_name: destination_chain_name,
             to_address,
           },


### PR DESCRIPTION
## Description

The second transaction fails when sending the base denom coin to a different chain via `/send/address`
Fixes: #732 

## Feature flags
N/A

## Testing
1. go to `/send/address`
2. Input an address that does not use the asset you plan to send as the base denom ex) send atom to an osmo address
3. add any memo to said transaction
4. proceed the transaction 

---

## Additional Details (Optional)
Sometimes the first transaction loads indefinitely for some reason. I think this might be another issue but hoping it only happens in the local environment.

## Reviews (Optional)
@clockworkgr 
