### PR TITLE
fix: empty notification for claim transactions

### DIFF
--- a/src/features/transactions/components/TransactionProcessItem.vue
+++ b/src/features/transactions/components/TransactionProcessItem.vue
@@ -67,7 +67,7 @@
           <Ticker :name="getBaseDenomSync(transactionAction.data.coinB.denom)" />
         </template>
         <template v-if="action === 'claim'">
-          Claim <Ticker :name="getBaseDenomSync(transactionAction.data.amount.denom)" />
+          Claim <Ticker :name="getBaseDenomSync(parseCoins(transactionAction.data.total)[0].denom)" />
         </template>
         <template v-if="action === 'stake'">
           Stake <Ticker :name="getBaseDenomSync(transactionAction.data[0].amount.denom)" />
@@ -199,6 +199,7 @@ import Spinner from '@/components/ui/Spinner.vue';
 import { GlobalDemerisGetterTypes } from '@/store';
 import { AddLiquidityData, CreatePoolData, SwapData, TransferData, WithdrawLiquidityData } from '@/types/actions';
 import { getBaseDenomSync } from '@/utils/actionHandler';
+import { parseCoins } from '@/utils/basic';
 
 import {
   getCurrentTransaction,

--- a/src/utils/basic.test.ts
+++ b/src/utils/basic.test.ts
@@ -1,0 +1,15 @@
+import { parseCoins } from './basic';
+
+test('should parse coins', () => {
+  expect(parseCoins('100abcd')).toStrictEqual([{ amount: '100', denom: 'abcd' }]);
+  // ibc
+  expect(parseCoins('2ibc/3F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2')).toStrictEqual([
+    { amount: '2', denom: 'ibc/3F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2' },
+  ]);
+  // with decimals
+  expect(parseCoins('123.45678abcd')).toStrictEqual([{ amount: '123', denom: 'abcd' }]);
+  expect(parseCoins('123.45678abcd,321.875dcba')).toStrictEqual([
+    { amount: '123', denom: 'abcd' },
+    { amount: '321', denom: 'dcba' },
+  ]);
+});

--- a/src/utils/basic.ts
+++ b/src/utils/basic.ts
@@ -160,7 +160,7 @@ export function parseCoins(input: string): Coin[] {
     .split(',')
     .filter(Boolean)
     .map((part) => {
-      const match = part.match(/^([0-9]+)([a-zA-Z0-9\/-]{2,127})$/);
+      const match = part.match(/^([0-9]+)(?:\.[0-9]+)?([a-zA-Z0-9\/-]{2,127})$/);
       if (!match) throw new Error('Got an invalid coin string');
       return {
         amount: BigInt(match[1]).toString(),

--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -210,7 +210,7 @@ export default defineComponent({
     };
 
     const onClose = () => {
-      transactionsStore.removeTransaction(transactionsStore.currentId);
+      transactionsStore.setTransactionAsPending(transactionsStore.currentId);
       const hasPrevPath = !!router.options.history.state.back;
       hasPrevPath ? router.back() : router.push('/');
     };


### PR DESCRIPTION
## Description

Fixes #1269 

- Now it uses the correct field (`total`) for the claim object.
- The `/delegatorrewards` endpoint may return a decimal value `123.4567uosmo`, so it updates regex to skip decimal places.

## Feature flags

VUE_APP_FEATURE_TRANSACTIONS_CENTER
VUE_APP_FEATURE_STAKING

## Testing

Claim a stake reward and see it in the transactions widget.