### PR TITLE
fix: Demo account default to true to fix issue

### DIFF
--- a/src/store/demeris-user/state.ts
+++ b/src/store/demeris-user/state.ts
@@ -1,6 +1,7 @@
 import * as API from '@/types/api';
 
 import { KeplrKeyData, UserData } from './mutation-types';
+
 export type ChainMeta = {
   verifiedTraces?: Record<string, API.VerifyTrace>;
   primaryChannels?: Record<string, API.PrimaryChannel>;
@@ -34,6 +35,8 @@ export function getDefaultState(): State {
     correlationId: '',
     keplr: null,
     _Subscriptions: new Set(),
-    _Session: {},
+    _Session: {
+      isDemoAccount: true,
+    },
   };
 }


### PR DESCRIPTION
## Description
Fixes: #1327 

## Feature flags

?VUE_APP_FEATURE_STAKING=1

## Testing

Open the console and access
https://app.emeris.com/asset/uatom?VUE_APP_FEATURE_STAKING=1 (will fix link)
See if there are any consistent calls to `/chain/undefined`

---

## Additional Details (Optional)
The fix may appear perplexing. Here's the rundown of how I came to this conclusion.
Thanks to @clockworkgr I was able to find that the premature call occurred in getOwnAddress
https://github.com/EmerisHQ/demeris/blob/production/src/utils/basic.ts#L48-L55
```
export async function getOwnAddress({ chain_name }) {
  const isCypress = !!window['Cypress'];
  const userstore = useStore() as TypedUSERStore;
  const apistore = useStore() as TypedAPIStore;
  if (userstore.getters[GlobalDemerisGetterTypes.USER.isDemoAccount]) {
    return demoAddresses[chain_name];
  } else {
    await apistore.dispatch(GlobalDemerisActionTypes.API.GET_CHAIN, { subscribe: true, params: { chain_name } });
```

My original approach was to add a dispatch to GET_VERIFIED_DENOMS per Alex's suggestion(https://github.com/EmerisHQ/demeris/issues/1327#issuecomment-1068005278)
but found that it was making WAYYY too many requests to the point that chrome ran out of resources.

Looking for a way to fix the issue, I found the only way for this to happen was if
`userstore.getters[GlobalDemerisGetterTypes.USER.isDemoAccount]` returned false for whatever reason despite the account being a demo one.
Hence initializing the value to true seemed like the way to go.
