### PR TITLE
Fix overflowing text in validator box

### DIFF
--- a/src/components/stake/ValidatorCard.vue
+++ b/src/components/stake/ValidatorCard.vue
@@ -21,7 +21,9 @@
       class="mt-3 py-1 px-3 rounded-3xl border border-negative-text text-negative-text -text-1"
       >Unavailable</span
     >
-    <p class="text-muted mt-4 w-full text-left">{{ validator.details }}</p>
+    <p class="text-muted mt-4 w-full text-left break-words">
+      {{ validator.details }}
+    </p>
     <List class="w-full mt-8">
       <ListItem size="sm" direction="col">
         <ListItem inset size="xs" :label="$t('components.validatorCard.commissionLabel')">


### PR DESCRIPTION
## Description

Fixes validator generated text that might overflow box if unbroken test is too long.

Fixes: # 1277


## Testing

Find a validator with very long strings in the description (such as cosmos address)

