### PR TITLE
Split long words in validator description text

### DIFF
--- a/src/components/stake/ValidatorCard.vue
+++ b/src/components/stake/ValidatorCard.vue
@@ -21,7 +21,7 @@
       class="mt-3 py-1 px-3 rounded-3xl border border-negative-text text-negative-text -text-1"
       >Unavailable</span
     >
-    <p class="text-muted mt-4 w-full text-left">{{ validator.details }}</p>
+    <p class="text-muted mt-4 w-full text-left break-words">{{ validator.details }}</p>
     <List class="w-full mt-8">
       <ListItem size="sm" direction="col">
         <ListItem inset size="xs" :label="$t('components.validatorCard.commissionLabel')">


### PR DESCRIPTION
## Description

Other issues in the ticket are already fixed so only fixes the issue of validator text with long unbroken strings so that they don't overflow their container.

Fixes: # 1277

## Testing

Open any validator details with long strings.
