### PR TITLE
fix/staking-table-total-no-nan

### DIFF
--- a/src/components/asset/StakeTable.vue
+++ b/src/components/asset/StakeTable.vue
@@ -36,9 +36,6 @@ const selectTab = (tabNumber?: number): void => {
 };
 
 const totalRewardsAmount = computed(() => {
-  if (stakingRewardsData.value?.total == '') {
-    return 0;
-  }
   return parseFloat(stakingRewardsData.value?.total ?? '0');
 });
 

--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -35,10 +35,14 @@ export default function useStaking() {
   const getStakingRewardsByBaseDenom = async (base_denom: string): Promise<StakingRewards> => {
     try {
       const chain_name = await getChainName(base_denom);
-      return await store.dispatch(GlobalActionTypes.API.GET_STAKING_REWARDS, {
+      const rewards = await store.dispatch(GlobalActionTypes.API.GET_STAKING_REWARDS, {
         subscribe: false,
         params: { chain_name },
       });
+      if (rewards.total === '') {
+        return { rewards: [], total: '0' + base_denom };
+      }
+      return rewards;
     } catch (_e) {
       // Apparently rewards endpoint errors out if staking rewards are zero
       // or user is not staking so we catch and return an entry for no rewards


### PR DESCRIPTION
## Description

- Fixes this issue for demo account for uakt asset for example:
![image](https://user-images.githubusercontent.com/1449065/158885405-69e8e843-b1d2-42c3-8f96-00f91eb3a562.png)

Probably this check needs to be somewhere else.
Also reported to the backend team ( https://allinbits.slack.com/archives/C02JXQVAP3K/p1647546741281899 ), but at least this fixes it for the time being to unblock.

Fixes https://app.zenhub.com/workspaces/emeris-front-end-61a8a3c678a51100170b686f/issues/emerishq/demeris/1356
