### PR TITLE
fix: Making the cookie-consent-accepted cookie's domain dynamic

### DIFF
--- a/src/components/common/CookieConsent.vue
+++ b/src/components/common/CookieConsent.vue
@@ -33,7 +33,12 @@ export default defineComponent({
     const { setCookie, getCookie } = useCookie();
     const consented = ref(getCookie('cookie-consent-accepted'));
     const acceptCookies = () => {
-      setCookie('cookie-consent-accepted', 'true', { domain: '.emeris.com' });
+      setCookie('cookie-consent-accepted', 'true', {
+        domain:
+          window.location.hostname === 'localhost'
+            ? 'localhost'
+            : `.${window.location.hostname.replace(/^(?:https?:\/\/)?(?:[^\/]+\.)?([^.\/]+\.[^.\/]+).*$/, '$1')}`,
+      });
       consented.value = 'true';
     };
     return { consented, acceptCookies };


### PR DESCRIPTION
## Description

This PR makes the cookie-consent-accepted domain dynamic.
I got annoyed that the cookie banner never disappears, so wanted to make it dynamic

In general, it takes ".{top-level-domain}"
For localhost, it takes "localhost"

This should ensure we only have to accept once for every environment, no matter whether locally, deploy preview or production