### PR TITLE
fix: improve-error-for-sentry

### DIFF
--- a/src/store/demeris-api/actions.ts
+++ b/src/store/demeris-api/actions.ts
@@ -282,7 +282,7 @@ export const actions: ActionTree<APIState, RootState> & Actions = {
         if (subscribe) {
           commit(MutationTypes.SUBSCRIBE, { action: ActionTypes.GET_POOL_BALANCES, payload: { params } });
         }
-        throw new SpVuexError('Demeris:GetBalances', 'Could not perform API query.');
+        throw new SpVuexError('Demeris:GetPoolBalances', 'Could not perform API query.');
       }
       commit(MutationTypes.DELETE_IN_PROGRESS, reqHash);
       resolver();


### PR DESCRIPTION
## Description
Only changed the name to be distinct for easier debugging in Sentry
from
```
throw new SpVuexError('Demeris:GetBalances', 'Could not perform API query.');
```
to
```
throw new SpVuexError('Demeris:GetPoolBalances', 'Could not perform API query.');
```