### PR TITLE
fix: report failure if ticket response is not completed

### DIFF
--- a/src/features/transactions/transactionProcessMachine.ts
+++ b/src/features/transactions/transactionProcessMachine.ts
@@ -473,7 +473,12 @@ export const transactionProcessMachine = createMachine<TransactionProcessContext
           }
 
           if (!['IBC_receive_success', 'complete'].includes(resultData.status) || resultData.error) {
-            throw new Error(resultData.error || 'error');
+            return callback({
+              // @ts-ignore
+              type: 'GOT_FAILURE',
+              error: resultData.error,
+              data: responseData,
+            });
           }
 
           if (resultData.status === 'IBC_receive_success') {


### PR DESCRIPTION
## Description

Just throwing an error results in an uncaught promise. Now it directly calls the callback method.

Fixes #1381 