### PR TITLE
fix: playwright 3 retries

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: 1,
+  retries: 3,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
## Description

Increased the Playwright retries to 3
Why?
Our tests are flaky, and it seems to be the same "Connect Keplr" problem as we had before with Cypress.
A proper solution still needs to come into place, this retry to 3 is just a temporary measure to make sure it doesn't block other development/merges

<img width="993" alt="image" src="https://user-images.githubusercontent.com/1449065/159657335-4905a023-9604-4812-9bcd-cbcd6c35988b.png">
<img width="893" alt="image" src="https://user-images.githubusercontent.com/1449065/159657360-245bece5-3b37-4728-80e9-3c9c65db3718.png">
