### PR TITLE
fix: Downgrade apexcharts to version that works for our setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/long": "^4.0.1",
         "@vueuse/core": "^8.1.2",
         "@xstate/vue": "^1.0.0",
-        "apexcharts": "3.33.2",
+        "apexcharts": "3.31.0",
         "autoprefixer": "^10",
         "axios": "^0.26.1",
         "bech32": "^2.0.0",
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.33.2.tgz",
-      "integrity": "sha512-GkHZ3o36ZT/jSBh5y1pxxRzwM3tvtladtkcUTfXwP0wYAHK8Qj0X4ZPsupP7emRIjhOVpGsCxW9xeO3F5w+AOQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.31.0.tgz",
+      "integrity": "sha512-Ba3yl1cUW241+ogFnKD+TXU0pHCor0WsjloAAuOq4SWF99Xjny+MRlKJmPWwpJH4cGuncZ4aJVk3zMsKKcApGA==",
       "dependencies": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",
@@ -12555,9 +12555,9 @@
       }
     },
     "apexcharts": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.33.2.tgz",
-      "integrity": "sha512-GkHZ3o36ZT/jSBh5y1pxxRzwM3tvtladtkcUTfXwP0wYAHK8Qj0X4ZPsupP7emRIjhOVpGsCxW9xeO3F5w+AOQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.31.0.tgz",
+      "integrity": "sha512-Ba3yl1cUW241+ogFnKD+TXU0pHCor0WsjloAAuOq4SWF99Xjny+MRlKJmPWwpJH4cGuncZ4aJVk3zMsKKcApGA==",
       "requires": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/long": "^4.0.1",
     "@vueuse/core": "^8.1.2",
     "@xstate/vue": "^1.0.0",
-    "apexcharts": "3.33.2",
+    "apexcharts": "3.31.0",
     "autoprefixer": "^10",
     "axios": "^0.26.1",
     "bech32": "^2.0.0",


### PR DESCRIPTION
## Description

Current versions of Apex charts https://github.com/apexcharts/apexcharts.js/tags break our chart display. I have fixed the package to specific version that works. We should monitor updates to the package to see when we can start using the latest again.

