### PR TITLE
fix: multiple get chains calls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -113,7 +113,7 @@ export default defineComponent({
       } catch (e) {
         console.error('Could not load verified denoms: ' + e);
       }
-      await typedstore
+      typedstore
         .dispatch(GlobalActionTypes.API.GET_CHAINS, {
           subscribe: false,
         })


### PR DESCRIPTION
## Description
Right now, in production, we load `GET_CHAINS` multiple times:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/1449065/160413988-b0228b59-4dbc-469e-8ba8-ea1705471114.png">

This PR is awaiting the first one, because without this information we can't start retrieving balances anyway:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/1449065/160414239-0eab5189-4d5f-4c1c-9782-3194f33ec438.png">

