### PR TITLE
fix: staking rewards bug

### DIFF
--- a/src/components/asset/StakeTable.vue
+++ b/src/components/asset/StakeTable.vue
@@ -13,6 +13,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import BigNumber from 'bignumber.js';
 import { computed, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 
@@ -24,6 +25,7 @@ import useAccount from '@/composables/useAccount';
 import useStaking, { StakingRewards } from '@/composables/useStaking';
 import { GlobalGetterTypes, RootStoreTyped } from '@/store';
 import { event } from '@/utils/analytics';
+import { parseCoins } from '@/utils/basic';
 
 const store = useStore() as RootStoreTyped;
 const stakingRewardsData = ref<StakingRewards>(null);
@@ -56,9 +58,13 @@ const selectTab = (tabNumber?: number): void => {
   selectedTab.value = tabNumber;
 };
 
+//  ignores denoms that are not from native chain
 const totalRewardsAmount = computed(() => {
   if (!stakingRewardsData.value?.total) return 0;
-  return parseFloat(stakingRewardsData.value.total ?? '0');
+  const total = parseCoins(stakingRewardsData.value?.total ?? '0')
+    .map((value) => (value.denom !== props.denom ? '0' : value.amount))
+    .reduce((prevValue, currentValue) => BigNumber.sum(prevValue, currentValue).toString());
+  return parseFloat(total ?? '0');
 });
 
 watch(


### PR DESCRIPTION
## Description
Made the StakeTable.vue component calculate the totalRewardsAmount correctly for edge cases.
The code currently ignores non-native chain rewards - not sure whether this is the right way to go. Maybe need some discussion @josietyleung 

Fixes: #1443 

## Feature flags

?VITE_FEATURE_STAKING=1

## Testing

I wasn't able to test it myself due to not having an account with the current rewards like this address but I imagine the applied fix will do the trick.
https://api.emeris.com/v1/account/ef1a0341412f0e8b62d2dd731f86f0641cc857da/delegatorrewards/osmosis

---

## Reviews (Optional)
I'm not sure who has the account that can test this so tagging all the participants in the issue.
@eitjuh @clockworkgr 