### PR TITLE
feat: validator sorting with inactive always at the bottom

### DIFF
--- a/src/components/stake/ValidatorsTable.vue
+++ b/src/components/stake/ValidatorsTable.vue
@@ -285,24 +285,36 @@ export default defineComponent({
       return propsRef.validatorList.value
         .filter((vali: any) => vali.moniker?.toLowerCase().indexOf(query) !== -1)
         .sort((a, b) => {
-          switch (sortBy.value) {
-            case 'power':
-              if (Number(a.tokens) < Number(b.tokens)) return sortOrder.value == 'asc' ? -1 : 1;
-              if (Number(a.tokens) > Number(b.tokens)) return sortOrder.value == 'asc' ? 1 : -1;
-              return 0;
-            case 'name':
-              if (a.moniker < b.moniker) return sortOrder.value == 'asc' ? -1 : 1;
-              if (a.moniker > b.moniker) return sortOrder.value == 'asc' ? 1 : -1;
-              return 0;
-            case 'commission':
-              if (Number(a.commission_rate) < Number(b.commission_rate)) return sortOrder.value == 'asc' ? -1 : 1;
-              if (Number(a.commission_rate) > Number(b.commission_rate)) return sortOrder.value == 'asc' ? 1 : -1;
-              return 0;
-            case 'staked':
-              if (Number(a.stakedAmount) < Number(b.stakedAmount)) return sortOrder.value == 'asc' ? -1 : 1;
-              if (Number(a.stakedAmount) > Number(b.stakedAmount)) return sortOrder.value == 'asc' ? 1 : -1;
-              return 0;
+          let res = 0;
+          //  if only one of a and b are offline
+          if ((isOffline(a) || isOffline(b)) && !(isOffline(a) && isOffline(b))) {
+            return isOffline(a) ? 1 : -1;
+          } else {
+            switch (sortBy.value) {
+              case 'power':
+                if (Number(a.tokens) < Number(b.tokens)) res = 1;
+                if (Number(a.tokens) > Number(b.tokens)) res = -1;
+                break;
+              case 'name':
+                if (a.moniker < b.moniker) res = 1;
+                if (a.moniker > b.moniker) res = -1;
+                break;
+              case 'commission':
+                if (Number(a.commission_rate) < Number(b.commission_rate)) res = 1;
+                if (Number(a.commission_rate) > Number(b.commission_rate)) res = -1;
+                break;
+              case 'staked':
+                if (Number(a.stakedAmount) < Number(b.stakedAmount)) res = 1;
+                if (Number(a.stakedAmount) > Number(b.stakedAmount)) res = -1;
+                break;
+            }
+            if (res === 0) {
+              if (Number(a.tokens) < Number(b.tokens)) res = 1;
+              if (Number(a.tokens) > Number(b.tokens)) res = -1;
+            }
           }
+          if (sortOrder.value === 'asc') return -res;
+          return res;
         });
     });
     const sort = (by) => {
@@ -350,9 +362,14 @@ export default defineComponent({
       sortBy,
       sortOrder,
       isDisabled,
+      isOffline,
     };
   },
 });
+
+function isOffline(validator: EmerisAPI.Validator) {
+  return validator.status === 1 || validator.status === 2;
+}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Description

Fixed the sorting related code in ValidatorsTable.vue s.t. inactive validators will stay in the bottom.
All ties are resolved by sorting via voting power by default

Fixes: #1393 

## Feature flags

?VITE_FEATURE_STAKING=1

## Testing
Go to `/staking/uatom/stake?VITE_FEATURE_STAKING=1` and try clicking the table column titles and see if the results are intuitive.

---