### PR TITLE
fix: increase wallet auto-login timeout to 30d

### DIFF
--- a/src/utils/basic.ts
+++ b/src/utils/basic.ts
@@ -87,9 +87,10 @@ export function getChannel(path, index) {
   const parts = path.split('/');
   return parts[index * 2 + 1];
 }
+const LOGIN_TIMEOUT = 1000 * 60 * 60 * 24 * 30; //  30 days
 export function autoLogin() {
   const last = window.localStorage.getItem('lastEmerisSession');
-  if (last && last != '' && Date.now() < parseInt(last) + 60000) {
+  if (last && last != '' && Date.now() < parseInt(last) + LOGIN_TIMEOUT) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
## Description
Increase auto-login duration to 30d

Fixes: #1442 

## Feature flags
N/A

## Testing
Open Emeris, Connect wallet, close the tab and wait for more than 1 minute and turn the tab back on. 
Check whether you're still logged in.

---
