### PR TITLE
fix: made enhancements on single airdrop page dark mode

### DIFF
--- a/src/components/airdrops/AirdropClaim/AirdropClaim.vue
+++ b/src/components/airdrops/AirdropClaim/AirdropClaim.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wrapper w-full relative">
-    <div class="claim-widget bg-surface dark:bg-fg rounded-2xl px-6 py-8 shadow-panel">
+    <div class="claim-widget bg-surface dark:bg-darkBanner rounded-2xl px-6 py-8 shadow-panel">
       <!-- Claim Header -->
       <!-- Has Airdrop amount -->
       <div class="text-center mb-6">

--- a/src/views/Airdrop.vue
+++ b/src/views/Airdrop.vue
@@ -1,6 +1,6 @@
 <template>
   <NoMarginLayout>
-    <header class="-mt-32 w-full bg-fg">
+    <header class="-mt-32 w-full header-bg">
       <div class="pt-24 pb-12 px-5 md:px-8 max-w-7xl mx-auto">
         <GoBack :title="`${$t('context.airdrops.allAirdrops')}`" @go-back="goBackToAirdropspage" />
         <!-- Airdrop Title -->
@@ -173,5 +173,11 @@ ul {
 }
 .description-text {
   line-height: 1.5;
+}
+.header-bg {
+  background: radial-gradient(100% 100% at 17.19% 0%, rgba(80, 206, 235, 0.08) 0%, rgba(22, 61, 70, 0.08) 100%);
+}
+.dark .header-bg {
+  background: radial-gradient(100% 100% at 17.19% 0%, rgba(80, 206, 235, 0.8) 0%, rgba(22, 61, 70, 0.8) 100%);
 }
 </style>


### PR DESCRIPTION
## Description
Fix the airdrop claim card below to display proper background when dark mode.
<img width="433" alt="Screenshot 2022-03-29 at 2 47 00 PM" src="https://user-images.githubusercontent.com/49952972/160625900-b3eb9713-1e26-40f4-8f0c-943c17c6e376.png">

Also fixed the airdrop page header background to display proper backgrounds when in both light and dark modes. See screenshots below:
<img width="1440" alt="Screenshot 2022-03-29 at 2 48 06 PM" src="https://user-images.githubusercontent.com/49952972/160626119-132072ae-ac60-48ff-851a-67f81baabd59.png">
<img width="1436" alt="Screenshot 2022-03-29 at 2 48 21 PM" src="https://user-images.githubusercontent.com/49952972/160626167-2b28ce30-75f7-46cc-ab61-92f4c4df54c7.png">


## Feature flags
Please use this feature flag to test - ?VITE_FEATURE_AIRDROPS_FEATURE=1

## Testing
1. Add feature flag to url.
2. Go to airdrops page.
3. Click on a single airdrop.
4. Changes mode in settings to dark mode to see dark mode design.
