### PR TITLE
feat: add debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Ensure you create an `.env.local` file, with the following:
 
 #Uncomment below to enable staging API's
 #VITE_FEATURE_USE_STAGING=true
+
+#Uncomment below to enable DEBUG mode
+#Debug mode means:
+#- No constant polling of balances (be careful with this, as you see things different than our customers)
+#VITE_FEATURE_DEBUG=true
 ```
 
 You can also use URL parameters to easily switch evironment, like this:

--- a/src/store/demeris-api/actions.ts
+++ b/src/store/demeris-api/actions.ts
@@ -14,6 +14,7 @@ import EmerisError from '@/utils/EmerisError';
 import TendermintWS from '@/utils/TendermintWS';
 
 import { RootStoreTyped } from '../';
+import { featureRunning } from './../../utils/FeatureManager';
 import { APIStore } from '.';
 import { ActionTypes } from './action-types';
 import { MutationTypes } from './mutation-types';
@@ -1070,9 +1071,11 @@ export const actions: ActionTree<APIState, RootState> & Actions = {
   ) {
     console.log('Vuex nodule: demeris initialized!');
     commit(MutationTypes.INIT, { wsEndpoint, endpoint, gitEndpoint, rawGitEndpoint, hub_chain, gas_limit });
-    setInterval(() => {
-      dispatch(ActionTypes.STORE_UPDATE);
-    }, refreshTime);
+    if (!featureRunning('DEBUG')) {
+      setInterval(() => {
+        dispatch(ActionTypes.STORE_UPDATE);
+      }, refreshTime);
+    }
   },
   [ActionTypes.RESET_STATE]({ commit }) {
     commit(MutationTypes.RESET_STATE);


### PR DESCRIPTION
## Description
Adding DEBUG mode for our development environment:
Add `VITE_FEATURE_DEBUG=true` to your URL or to your `.env.local` file, and enjoy Emeris without the every-5-seconds polling of balances

Just to be clear: This is not meant to be turned on in prod (technically customers can, I didn't bother disabling this functionality in prod because there is nothing secret behind this flag)