### PR TITLE
refactor: total portfolio balance composable

### DIFF
--- a/src/components/account/AvatarBalance.vue
+++ b/src/components/account/AvatarBalance.vue
@@ -24,7 +24,7 @@
         {{ keplrAccountName }}
       </div>
       <div :class="[walletName ? '-text-1 text-muted' : 'text-0 font-medium leading-none']">
-        <TotalPrice v-if="isPriceApiAvailable && initialLoadComplete" class="inline" :balances="balances" />
+        <TotalPrice v-if="isPriceApiAvailable && initialLoadComplete" class="inline" />
         <SkeletonLoader v-else width="100%">
           <span v-if="walletName" class="ml-1">&middot; {{ walletName }}</span>
         </SkeletonLoader>
@@ -41,7 +41,6 @@ import { useStore } from 'vuex';
 
 import SkeletonLoader from '@/components/common/loaders/SkeletonLoader.vue';
 import TotalPrice from '@/components/common/TotalPrice.vue';
-import useAccount from '@/composables/useAccount';
 import { GlobalGetterTypes } from '@/store';
 
 export default defineComponent({
@@ -58,8 +57,6 @@ export default defineComponent({
   setup() {
     const store = useStore();
 
-    const { balances } = useAccount();
-
     const keplrAccountName = computed(() => {
       return store.getters[GlobalGetterTypes.USER.getKeplrAccountName];
     });
@@ -74,7 +71,6 @@ export default defineComponent({
       return !store.getters[GlobalGetterTypes.USER.getFirstLoad];
     });
     return {
-      balances,
       keplrAddress,
       initialLoadComplete,
       keplrAccountName,

--- a/src/components/common/TotalPrice.vue
+++ b/src/components/common/TotalPrice.vue
@@ -4,131 +4,21 @@
   </div>
 </template>
 <script lang="ts">
-import { EmerisAPI } from '@emeris/types';
-import { computed, defineComponent, PropType, toRefs } from 'vue';
-import { useStore } from 'vuex';
+import { defineComponent, PropType } from 'vue';
 
 import CurrencyDisplay from '@/components/ui/CurrencyDisplay.vue';
-import useAccount from '@/composables/useAccount';
-import { GlobalGetterTypes, RootStoreTyped } from '@/store';
+import { useTotalPortfolioBalance } from '@/composables/useTotalPortfolioBalance';
 
 export default defineComponent({
   components: { CurrencyDisplay },
   props: {
-    balances: {
-      type: Array as PropType<EmerisAPI.Balances>,
-      required: true,
-    },
     smallDecimals: {
       type: Boolean as PropType<true | false>,
       default: false,
     },
   },
-  setup(props) {
-    const store = useStore() as RootStoreTyped;
-    const propsRef = toRefs(props);
-    const { stakingBalances, unbondingDelegations } = useAccount();
-
-    const verifiedDenoms = computed(() => store.getters[GlobalGetterTypes.API.getVerifiedDenoms]);
-    const liquidValue = computed(() => {
-      if (propsRef.balances.value.length > 0) {
-        return propsRef.balances.value.reduce((total, balance) => {
-          if (balance.verified) {
-            if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: balance.base_denom })) {
-              let totalValue =
-                parseInt(balance.amount) * store.getters[GlobalGetterTypes.API.getPrice]({ denom: balance.base_denom });
-              let precision = Math.pow(
-                10,
-                store.getters[GlobalGetterTypes.API.getDenomPrecision]({
-                  name: balance.base_denom,
-                }) || 6,
-              );
-              let value = totalValue / precision;
-              if (value) {
-                return total + value;
-              } else {
-                return total;
-              }
-            } else {
-              return total;
-            }
-          } else {
-            return total;
-          }
-        }, 0);
-      } else {
-        return 0;
-      }
-    });
-    const stakedValue = computed(() => {
-      return stakingBalances.value.reduce((total, stakingBalance) => {
-        const stakedDenom = verifiedDenoms.value.filter((x) => x.chain_name == stakingBalance.chain_name && x.stakable);
-        if (stakedDenom.length > 0) {
-          if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: stakedDenom[0].name })) {
-            let totalValue =
-              parseInt(stakingBalance.amount) *
-                store.getters[GlobalGetterTypes.API.getPrice]({ denom: stakedDenom[0].name }) ?? 0;
-            let precision = Math.pow(
-              10,
-              store.getters[GlobalGetterTypes.API.getDenomPrecision]({
-                name: stakedDenom[0].name,
-              }) || 6,
-            );
-            let value = totalValue / precision;
-            if (value) {
-              return total + value;
-            } else {
-              return total;
-            }
-          } else {
-            return total;
-          }
-        } else {
-          return total;
-        }
-      }, 0);
-    });
-    const unstakingValue = computed(() => {
-      return unbondingDelegations.value.reduce((total, unstakingBalance) => {
-        const unstakedDenom = verifiedDenoms.value.filter(
-          (x) => x.chain_name == unstakingBalance.chain_name && x.stakable,
-        );
-
-        if (unstakedDenom.length > 0) {
-          let unstakedAmount;
-          const unstakedAmounts = unstakingBalance.entries.map((z) => z.balance);
-          if (unstakedAmounts.length > 0) {
-            unstakedAmount = unstakedAmounts.reduce((acc, item) => +parseInt(item) + acc, 0);
-          }
-          if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: unstakedDenom[0].name })) {
-            let totalValue =
-              parseInt(unstakedAmount) *
-                store.getters[GlobalGetterTypes.API.getPrice]({ denom: unstakedDenom[0].name }) ?? 0;
-            let precision = Math.pow(
-              10,
-              store.getters[GlobalGetterTypes.API.getDenomPrecision]({
-                name: unstakedDenom[0].name,
-              }) || 6,
-            );
-            let value = totalValue / precision;
-            if (value) {
-              return total + value;
-            } else {
-              return total;
-            }
-          } else {
-            return total;
-          }
-        } else {
-          return total;
-        }
-      }, 0);
-    });
-    const displayPrice = computed(() => {
-      const value = liquidValue.value + stakedValue.value + unstakingValue.value;
-      return Number.isFinite(value) ? value : 0;
-    });
-    return { displayPrice };
+  setup() {
+    return { displayPrice: useTotalPortfolioBalance() };
   },
 });
 </script>

--- a/src/composables/useTotalPortfolioBalance.ts
+++ b/src/composables/useTotalPortfolioBalance.ts
@@ -1,0 +1,114 @@
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+import useAccount from '@/composables/useAccount';
+import { GlobalGetterTypes, RootStoreTyped } from '@/store';
+
+export function useTotalPortfolioBalance() {
+  const { balances } = useAccount();
+
+  const store = useStore() as RootStoreTyped;
+  const { stakingBalances, unbondingDelegations } = useAccount();
+
+  const verifiedDenoms = computed(() => store.getters[GlobalGetterTypes.API.getVerifiedDenoms]);
+  const liquidValue = computed(() => {
+    if (balances.value.length > 0) {
+      return balances.value.reduce((total, balance) => {
+        if (balance.verified) {
+          if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: balance.base_denom })) {
+            const totalValue =
+              parseInt(balance.amount) * store.getters[GlobalGetterTypes.API.getPrice]({ denom: balance.base_denom });
+            const precision = Math.pow(
+              10,
+              store.getters[GlobalGetterTypes.API.getDenomPrecision]({
+                name: balance.base_denom,
+              }) || 6,
+            );
+            const value = totalValue / precision;
+            if (value) {
+              return total + value;
+            } else {
+              return total;
+            }
+          } else {
+            return total;
+          }
+        } else {
+          return total;
+        }
+      }, 0);
+    } else {
+      return 0;
+    }
+  });
+  const stakedValue = computed(() => {
+    return stakingBalances.value.reduce((total, stakingBalance) => {
+      const stakedDenom = verifiedDenoms.value.filter((x) => x.chain_name == stakingBalance.chain_name && x.stakable);
+      if (stakedDenom.length > 0) {
+        if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: stakedDenom[0].name })) {
+          const totalValue =
+            parseInt(stakingBalance.amount) *
+              store.getters[GlobalGetterTypes.API.getPrice]({ denom: stakedDenom[0].name }) ?? 0;
+          const precision = Math.pow(
+            10,
+            store.getters[GlobalGetterTypes.API.getDenomPrecision]({
+              name: stakedDenom[0].name,
+            }) || 6,
+          );
+          const value = totalValue / precision;
+          if (value) {
+            return total + value;
+          } else {
+            return total;
+          }
+        } else {
+          return total;
+        }
+      } else {
+        return total;
+      }
+    }, 0);
+  });
+  const unstakingValue = computed(() => {
+    return unbondingDelegations.value.reduce((total, unstakingBalance) => {
+      const unstakedDenom = verifiedDenoms.value.filter(
+        (x) => x.chain_name == unstakingBalance.chain_name && x.stakable,
+      );
+
+      if (unstakedDenom.length > 0) {
+        let unstakedAmount;
+        const unstakedAmounts = unstakingBalance.entries.map((z) => z.balance);
+        if (unstakedAmounts.length > 0) {
+          unstakedAmount = unstakedAmounts.reduce((acc, item) => +parseInt(item) + acc, 0);
+        }
+        if (store.getters[GlobalGetterTypes.API.getPrice]({ denom: unstakedDenom[0].name })) {
+          const totalValue =
+            parseInt(unstakedAmount) *
+              store.getters[GlobalGetterTypes.API.getPrice]({ denom: unstakedDenom[0].name }) ?? 0;
+          const precision = Math.pow(
+            10,
+            store.getters[GlobalGetterTypes.API.getDenomPrecision]({
+              name: unstakedDenom[0].name,
+            }) || 6,
+          );
+          const value = totalValue / precision;
+          if (value) {
+            return total + value;
+          } else {
+            return total;
+          }
+        } else {
+          return total;
+        }
+      } else {
+        return total;
+      }
+    }, 0);
+  });
+  const displayPrice = computed(() => {
+    const value = liquidValue.value + stakedValue.value + unstakingValue.value;
+    return Number.isFinite(value) ? value : 0;
+  });
+
+  return displayPrice;
+}

--- a/src/views/Portfolio.vue
+++ b/src/views/Portfolio.vue
@@ -5,7 +5,7 @@
         <header>
           <div class="-text-1 md:text-0 text-muted">{{ $t('context.assets.totalBalance') }}</div>
           <div class="text-2 sm:text-3 md:text-4 lg:text-5 font-bold mt-1 md:mt-2">
-            <TotalPrice v-if="initialLoadComplete" :balances="balances" small-decimals />
+            <TotalPrice v-if="initialLoadComplete" small-decimals />
             <SkeletonLoader v-else width="100%" />
           </div>
         </header>


### PR DESCRIPTION
## Description
Small refactor, moving total portfolio price logic from the template in a composable, so we can further refactor it later
Code is simply copied into a composable file and removed from the template, nothing more.

Only used in `TotalPrice` component, which is used in `Portfolio.vue` and `AvatarBalance.vue`
