### PR TITLE
fix: hide graphs without data

### DIFF
--- a/src/components/common/charts/AreaChart.vue
+++ b/src/components/common/charts/AreaChart.vue
@@ -199,7 +199,7 @@ export default defineComponent({
     );
 
     const hasData = computed(() => {
-      return chartData.value.series[0].data && chartData.value.series[0].data.length > 0;
+      return chartData.value.series[0].data && chartData.value.series[0].data.length > 1;
     });
 
     const emitPriceDiffObject = (openingPrice, closingPrice, indicator): void => {


### PR DESCRIPTION
## Description

Some denoms don't have chart data. Since last changes, the latest price is appended to the chart which requires this fix for the charts to be hidden if no timeseries data is present.

