### PR TITLE
fix: fixed airdrop logo not displaying correctly on airdrop claim card and airdrop current balance card

### DIFF
--- a/src/components/airdrops/AirdropClaim/AirdropClaim.vue
+++ b/src/components/airdrops/AirdropClaim/AirdropClaim.vue
@@ -6,13 +6,13 @@
       <div class="text-center mb-6">
         <div class="w-1/4 mx-auto mb-6">
           <img
-            v-if="selectedAirdrop.tokenIcon"
+            v-if="selectedAirdrop.tokenIcon && selectedAirdrop.imageExists"
             :src="selectedAirdrop.tokenIcon"
             alt="Airdrop Logo"
             class="w-full rounded-full"
           />
           <div v-else class="w-20 h-20 bg-text text-inverse rounded-full text-center pt-4 text-3 font-bold">
-            {{ selectedAirdrop.chainName.slice(0, 1) }}
+            {{ selectedAirdrop.project.slice(0, 2) }}
           </div>
         </div>
 

--- a/src/components/airdrops/AirdropsCurrentBalance/AirdropsCurrentBalance.vue
+++ b/src/components/airdrops/AirdropsCurrentBalance/AirdropsCurrentBalance.vue
@@ -4,13 +4,13 @@
     <div class="flex justify-between items-center">
       <div class="w-10 h-10 mr-4">
         <img
-          v-if="selectedAirdrop.tokenIcon"
+          v-if="selectedAirdrop.tokenIcon && selectedAirdrop.imageExists"
           :src="selectedAirdrop.tokenIcon"
           alt="Airdrop Logo"
           class="rounded-full"
         />
         <div v-else class="w-10 h-10 bg-text text-inverse rounded-full text-center pt-1.5 text-1">
-          {{ selectedAirdrop.chainName.slice(0, 1) }}
+          {{ selectedAirdrop.project.slice(0, 2) }}
         </div>
       </div>
       <div class="w-10/12">


### PR DESCRIPTION
## Description
Airdrop logo was not displaying correctly in airdrop claim card on single airdrop page for some airdrop projects (coolcat and racoon).

## Feature flags
Please use this feature flag to test ?VITE_FEATURE_AIRDROPS_FEATURE=1

## Testing
1. Add feature flag ?VITE_FEATURE_AIRDROPS_FEATURE=1 to url
2. Go to airdrops page
3. Click on a single airdrop
4. See fix

## Screenshots (Optional)
<img width="433" alt="Screenshot 2022-04-04 at 12 51 39 PM" src="https://user-images.githubusercontent.com/49952972/161552263-9ebaf4a1-c71c-4b23-aa0d-eb47fdbb4be5.png">

