### PR TITLE
fix: airdrop copy not displaying properly

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -273,10 +273,8 @@
         "withdrawLiqAction": "Withdrawing liquidity",
         "withdrawing": "Withdrawing",
         "transferred": "Transferred",
-
         "reset": "Send another",
         "next": "Next transaction",
-
         "sendAfterSwap": "Send {displayName} \u2192",
         "genericActionComplete": "Transaction complete",
         "transferActionComplete": "Assets transferred",
@@ -547,6 +545,19 @@
           "searchingAirdrops": "Searching 12/34 airdrops",
           "noAirdropsToClaim": "No airdrops to claim",
           "checkOutForEligibility": "Check out the upcoming airdrops and find out if you’re eligible"
+        },
+        "claimCard": {
+          "ended": "Airdrop ended",
+          "comingSoon": "Airdrop coming soon",
+          "becomeEligible": "You could become eligible for this airdrop",
+          "amountTitle": "Your Airdrop amount",
+          "airdropAmount": "126.54 LIKE",
+          "autoDrop": "Auto-drop",
+          "notAnnounced": "Not announced",
+          "snapshotDate": "Snapshot Date",
+          "starts": "Starts",
+          "ends": "Ends",
+          "distribution": "Distribution"
         },
         "airdropsInfo": {
           "title": "Introduction",


### PR DESCRIPTION
## Description
The text on the airdrop claim card is not displaying as it should. It has something to do with the en.ts or en.json files.

To Reproduce
Add feature flag ?VITE_FEATURE_AIRDROPS_FEATURE=1 to url
Go to airdrops page
Click on a single airdrop
See fix on airdrop claim card

<img width="570" alt="Screenshot 2022-04-04 at 12 49 09 PM" src="https://user-images.githubusercontent.com/49952972/161553313-80e840b6-502c-4a7f-8a6e-d18ce5fcb1df.png">
