### PR TITLE
fix: #1313 chart data not loading

### DIFF
--- a/src/views/Asset.vue
+++ b/src/views/Asset.vue
@@ -229,7 +229,6 @@ export default defineComponent({
 
   setup() {
     const displayName = ref('');
-    const tokenTicker = ref('');
     const displayPrice = ref(0);
     const metaSource = computed(() => {
       return { title: displayName.value };
@@ -426,11 +425,11 @@ export default defineComponent({
       });
 
       getTokenPrices.value = async (days: string, showSkeleton: boolean) => {
-        tokenTicker.value = await getTicker(denom.value, typedstore.getters[GlobalGetterTypes.API.getDexChain]);
+        const tokenTicker = await getTicker(denom.value, typedstore.getters[GlobalGetterTypes.API.getDexChain]);
         const chainName = await typedstore.dispatch(GlobalActionTypes.API.GET_COINGECKO_ID_BY_NAMES, {
           subscribe: false,
           params: {
-            token: tokenTicker.value.toLowerCase(),
+            token: tokenTicker.toLowerCase(),
             showSkeleton: false,
           },
         });


### PR DESCRIPTION
## Description

After some debugging, it was discovered the chart component was using the denom display name as part of the gecko request, which accepts instead the ticker in lowecase. 

Fixes: # 1313


## Testing

All assets should now load with price graphs
