### PR TITLE
chore: enforce script setup in eslint warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'simple-import-sort/exports': 'error',
     'vue/multi-word-component-names': 'off',
     'vue/v-on-event-hyphenation': 'off',
+    'vue/component-api-style': ['warn', ['script-setup']],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-unused-vars': [


### PR DESCRIPTION
## Description

Warns when script setup is not used in components. As per our coding frontend guidelines:
https://www.notion.so/allinbits/Frontend-Engineering-Guidelines-873d2c6e2dda493fbf6601d527259efd#e8f5289554f842b78e47eafbc1b34cb4 

Fixes: # 1504

## Testing

Attempt to add composition API or options API should show eslint warning

