### PR TITLE
fix: prevent users from inputting sub 100 micro values for swaps

### DIFF
--- a/src/components/liquidity/Swap.vue
+++ b/src/components/liquidity/Swap.vue
@@ -217,7 +217,7 @@ export default defineComponent({
       //conditional-text-start
       buttonName: computed(() => {
         if (data.swapButtonActionText?.includes('Min')) {
-          return 'Below Min. Amount';
+          return t('components.swap.inputBelowMin');
         }
         if (data.isBothSelected) {
           if (!data.selectedPoolData) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -315,6 +315,7 @@
         "noPool": "No pool for this pair",
         "swapLimit": "Swap limit reached",
         "insufficentFunds": "Insufficent funds",
+        "inputBelowMin": "Below Min. Amount",
         "unAvailable": "Swap unavailable",
         "updatePrice": "Update prices",
         "review": "Review",


### PR DESCRIPTION
## Description

Prevents users from inputting sub 100 micro values and getting errors

Fixes: #1351 

## Feature flags

N/A

## Testing

In the swap widget,
try any denom and try to enter less than 100 micro of said denom.
It should not be swappable + the max button should change to a 'min' button where if pressed
the minimum value is set(100 micro)

---
