### PR TITLE
Feat/dex agg 0

### DIFF
--- a/src/components/swap/DexSwap.vue
+++ b/src/components/swap/DexSwap.vue
@@ -462,7 +462,7 @@ const assetsToReceive = computed(() => {
   );
 });
 
-const dex = computed(() => capitalizeFirstLetter(daggRoutes.value[0]?.steps[0]?.protocol));
+const dex = computed(() => capitalizeFirstLetter(daggRoutes.value[selectedQuoteIndex.value]?.steps[0]?.protocol));
 const expectedRate = computed(() =>
   ((data?.receiveCoinAmount * 10 ** toPrecision.value) / (data?.payCoinAmount * 10 ** fromPrecision.value)).toFixed(8),
 );


### PR DESCRIPTION
## Description

As in issue.

Fixes: #1535 

## Feature flags

VITE_FEATURE_DEX_AGG=true

## Testing

Select pay,receive denoms.. Enter pay/receive amount.. Click on Gravity/Osmosis ... Select another quote  ---> Dex displayed should change and should not be the best price dex always.

---

## Additional Details (Optional)

Untested because API is returning 1 route atm.
