### PR TITLE
chore: eslint add file and function limit warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
     '@vue/eslint-config-prettier',
   ],
   rules: {
+    'max-lines': [1, { max: 300, skipBlankLines: true, skipComments: true }],
+    'max-lines-per-function': [1, { max: 50, skipBlankLines: true, skipComments: true }],
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     'vue/multi-word-component-names': 'off',


### PR DESCRIPTION
## Description
Adds new eslint warnings for files with max line > 300 and max-lines-per-function > 50
Slowly creating some awareness of the need for refactoring

Fixes https://github.com/emerishq/demeris/issues/1505