### PR TITLE
feat: sorted airdrops on airdrops table alphabetically

### DIFF
--- a/src/components/airdrops/AirdropsTableSection/AirdropsTableSection.vue
+++ b/src/components/airdrops/AirdropsTableSection/AirdropsTableSection.vue
@@ -54,9 +54,7 @@ export default {
     };
 
     const airdrops = computed(() => {
-      const airdropsToBeSorted = typedstore.getters[GlobalGetterTypes.API.getAirdrops];
-      const sortedAirdrops = airdropsToBeSorted.sort(sortAirdropstable);
-      return sortedAirdrops;
+      return typedstore.getters[GlobalGetterTypes.API.getAirdrops].sort(sortAirdropstable);
     });
 
     const openAirdropPage = (airdrop: EmerisAirdrops.Airdrop) => {


### PR DESCRIPTION
## Description
Sorted the airdrops on the airdrops table alphabetically.

## Feature flags
Use this feature flag for testing ?VITE_FEATURE_AIRDROPS_FEATURE=1

## Testing

1. Add feature flag to url
2. Go to airdrops page
3. See sorted airdrops on airdrops table

<img width="1421" alt="Screenshot 2022-04-08 at 1 49 25 PM" src="https://user-images.githubusercontent.com/49952972/162438808-e303d67d-e65d-46a0-89a1-4f69f581e5d1.png">

