### PR TITLE
fix: removes unused chaindownwrapper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,12 @@ module.exports = {
     'vue/multi-word-component-names': 'off',
     'vue/v-on-event-hyphenation': 'off',
     'vue/component-api-style': ['warn', ['script-setup']],
+    'vue/no-undef-components': [
+      'error',
+      {
+        ignorePatterns: ['apexchart', 'i18n-n', 'i18n-t', 'metainfo', 'router-link', 'router-view', 'tippy'],
+      },
+    ],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,9 +5,7 @@
   <MaintenanceScreen v-if="showMaintenanceScreen" />
   <div v-else-if="initialized">
     <CookieConsent />
-    <ChainDownWrapper>
-      <router-view />
-    </ChainDownWrapper>
+    <router-view />
     <TransactionsCenter />
     <SimplexModal />
     <MoonpayModal />


### PR DESCRIPTION
## Description

Removes unused chaindownwrapper component and adds a rule in eslintrc for giving an error when a component is used but not imported.

Fixes: #1117 

## Feature flags

NA

## Testing

Add the chaindownwrapper tag back and check if you get an error.

## Screenshot
<img width="1011" alt="Screenshot 2022-04-12 at 12 37 51 AM" src="https://user-images.githubusercontent.com/12444344/162812059-c1ecab81-646d-4e7f-8dfe-d32d258508bf.png">

