### PR TITLE
fix: airdrop break e2e tests

### DIFF
--- a/src/utils/airdropEligibility.ts
+++ b/src/utils/airdropEligibility.ts
@@ -61,9 +61,13 @@ export function getAirdropEligibility(airdrop: Airdrop) {
     when the projects format there responses correctly. 
     After which we will be comparing each response per 
     address checked and adding the eligible amounts all together */
-    return eligibility_check_responses[0].then((res) => {
-      return res.eligibility;
-    });
+    if (eligibility_check_responses.length > 0) {
+      return eligibility_check_responses[0].then((res) => {
+        return res.eligibility;
+      });
+    } else {
+      return AirdropEligibilityStatus.NOT_AVAILABLE;
+    }
   } else {
     return AirdropEligibilityStatus.NOT_AVAILABLE;
   }


### PR DESCRIPTION
## Description
E2e tests were broken locally for me because I had enabled airdrops in my .env.local file
This error was causing the tests to break:
![image](https://user-images.githubusercontent.com/1449065/162993588-4b5047c8-7eda-4d1e-abfb-003edf95489f.png)

This fix simply puts a check around it to see if this eligibility_check_responses has items in it