### PR TITLE
fix: start websocket fallback immediately

### DIFF
--- a/src/components/liquidity/Swap.vue
+++ b/src/components/liquidity/Swap.vue
@@ -392,7 +392,10 @@ export default defineComponent({
       }
 
       if (transactionsStore.currentId) {
-        const snapshot = transactionsStore.getCurrentService().getSnapshot();
+        const snapshot = transactionsStore.getCurrentService()?.getSnapshot();
+        if (!snapshot) {
+          return;
+        }
         const cursor = getTransactionOffset(snapshot.context);
         if (snapshot.matches('transacting') || (cursor && cursor.total > cursor.offset)) {
           transactionsStore.setTransactionAsPending();

--- a/src/components/wizard/previews/PreviewSwap.vue
+++ b/src/components/wizard/previews/PreviewSwap.vue
@@ -47,6 +47,7 @@
     <ListItem :size="size" :label="$t('components.previews.swap.priceLbl')" direction="col">
       <!-- minReceivedAmount -->
       <ListItem
+        v-if="minReceivedAmount?.denom"
         :size="size"
         :description="$t('components.previews.swap.minReceivedLbl')"
         :hint="$t('components.previews.swap.minReceivedLblHint')"

--- a/src/store/demeris-api/actions/transactions.ts
+++ b/src/store/demeris-api/actions/transactions.ts
@@ -93,7 +93,7 @@ export const TransactionActions: ActionTree<APIState, RootState> & TransactionAc
 
       const wsUrl = `${getters['getWebSocketEndpoint']}/chain/${chain_name}/rpc/websocket`;
 
-      const wss = new TendermintWS({ server: wsUrl, timeout: 5000, autoReconnect: false });
+      const wss = new TendermintWS({ server: wsUrl, timeout: 5000, autoReconnect: true });
       const txHash64 = Buffer.from(txhash, 'hex').toString('base64');
       const subscribeQuery = `tm.event = 'Tx' AND tx.hash = '${txhash}'`;
 
@@ -161,15 +161,17 @@ export const TransactionActions: ActionTree<APIState, RootState> & TransactionAc
       };
 
       await wss.connect().catch(handleError);
-      handleOpen();
 
       intervalId = setInterval(() => {
+        if (done) return;
         dispatch(ActionTypes.GET_TX_FROM_RPC, { chain_name, txhash }).then(handleMessage);
       }, fallbackIntervalMs);
 
       timeoutId = setTimeout(() => {
         handleError(new Error('Could not find transaction response'));
       }, timeoutMs);
+
+      handleOpen();
     });
   },
 


### PR DESCRIPTION
## Description

If any websocket call fails, it should not prevent the fallback from starting.

Also enable automatic websocket reconnection and some component tweaks.

## Feature flags

VITE_FEATURE_WEBSOCKET_RESPONSE=1

## Testing

Make some transactions and see if it works.