### PR TITLE
fix: prevent api calls when chainnames are undefined

### DIFF
--- a/src/utils/api-settings.ts
+++ b/src/utils/api-settings.ts
@@ -4,7 +4,7 @@ export function axiosInit() {
   axios.interceptors.request.use(axiosIntercepter);
 }
 
-const falsyRegex = /(=undefined|=null)+/;
+const falsyRegex = /([=/]+undefined|[=/]+null)+/;
 const axiosIntercepter = (config: AxiosRequestConfig) => {
   if (falsyRegex.test(config.url) || config.url === undefined) {
     throw new Error(`Request url includes undefined or null - [${config.url}]`);


### PR DESCRIPTION
## Description
When the chainname is undefined, the route usually includes `chain/undefined/` which is not caught by the current regex

## Feature flags
N/A

## Testing
See if calls to `https://api.emeris.com/v1/chain/undefined/status` ever happen(Not recently but have seen in edge cases before)

---