### PR TITLE
chore: eslint add no inline styles rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,12 @@ module.exports = {
         bracketSameLine: false,
       },
     ],
+    'vue/no-static-inline-styles': [
+      'warn',
+      {
+        allowBinding: false,
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
## Description

Adding an eslint warning for inline styles.
It's not super many, but I just want to start making it clear that we don't want to have this 