### PR TITLE
fix: ambiguous 'sign transaction later' to 'OK'

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -691,7 +691,7 @@
       "confirm": "Confirm",
       "close": "Close",
       "continue": "Continue",
-      "signLater": "Sign transaction later",
+      "signLater": "OK",
       "noFunds": "Insufficient funds",
       "insufficientAmount": "Insufficient amount",
       "filterNoResults": "No results for '{keyword}'",


### PR DESCRIPTION
## Description

Fixes: #1618 

## How to reproduce

- Create a 'move' transaction but reduce the gas in the Keplr popup from 50k to 20k to make sure it takes too long
- Create another 'move' transaction and see the 'Pending Transaction' modal with the button as OK