### PR TITLE
fix: fixed arrow misalignment on no claimable airdrops banner

### DIFF
--- a/src/components/airdrops/AirdropClaim/AirdropClaimablePanel.vue
+++ b/src/components/airdrops/AirdropClaim/AirdropClaimablePanel.vue
@@ -60,8 +60,8 @@
       <div class="lg:w-1/2 md:w-1/2 w-1/2 py-8 px-6">
         <p class="lg:text-2 sm:text-0 font-bold mb-4">{{ $t('context.airdrops.claimablepanel.noAirdropsToClaim') }}</p>
         <p class="-text-1 text-dark mb-1">
-          {{ $t('context.airdrops.claimablepanel.checkOutForEligibility')
-          }}<Icon name="ArrowRightIcon" :icon-size="0.6" class="ml-2" />
+          {{ $t('context.airdrops.claimablepanel.checkOutForEligibility') }}
+          <Icon name="ArrowRightIcon" :icon-size="0.6" class="ml-2 inline-flex" />
         </p>
       </div>
 


### PR DESCRIPTION
## Description
Fixed issue #1474

## Feature flags
Please use feature flag ?VITE_FEATURE_AIRDROPS_FEATURE=1 for this

## Testing
Add feature flag to url
Go to airdrops page
If you have no claimable airdrops, see no claimable airdrops banner and arrow well aligned. Screenshot below:
<img width="1041" alt="Screenshot 2022-04-21 at 3 08 33 PM" src="https://user-images.githubusercontent.com/49952972/164476344-b19ebba6-8f16-4c94-a33e-b1beca2fdd1c.png">

