### PR TITLE
fix: fixed issue #1615

### DIFF
--- a/src/components/airdrops/AirdropClaim/AirdropClaimablePanel.vue
+++ b/src/components/airdrops/AirdropClaim/AirdropClaimablePanel.vue
@@ -149,7 +149,12 @@ export default defineComponent({
     });
 
     const showNoAirdropsToClaimBanner = computed(() => {
-      return !isDemoAccount.value && !airdropsLoading.value && noAirdropsToClaim.value;
+      return (
+        !isDemoAccount.value &&
+        !airdropsLoading.value &&
+        noAirdropsToClaim.value &&
+        (props.activeFilter === 'mine' || props.activeFilter === 'all')
+      );
     });
 
     const goToUpcomingAirdrops = () => {


### PR DESCRIPTION
## Description
Fixed Upcoming and Live sections of airdrops table displaying even though wallet is not connected. Check out issue #1615 for more details.

## Feature flags
Use this feature flag ?VITE_FEATURE_AIRDROPS_FEATURE=1 to test

## Testing

1. Add feature flag to url
2. Go to airdrops page
3. Make sure wallet is not connected
4. Click on upcoming filter and see upcoming airdrops displayed
5. Click on live filter and see live airdrops displayed
6. Connect wallet
7. Click on upcoming filter and see upcoming (eligible, not eligible, and eligibility unavailable) airdrops displayed
8. Click on live filter and see live (eligible, not eligible, and eligibility unavailable) airdrops displayed
