### PR TITLE
fix: alignment portfolio asset table

### DIFF
--- a/src/components/assets/AssetsTable/AssetsTable.vue
+++ b/src/components/assets/AssetsTable/AssetsTable.vue
@@ -247,7 +247,7 @@ export default defineComponent({
 
     const tableColumns = ref(['35%', '20%', '35%', '10%']);
     if (featureRunning('STAKING_PORTFOLIO') && props.showAvailableAsset) {
-      tableColumns.value = ['20%', '15%', '35%', '20%', '10%'];
+      tableColumns.value = ['25%', '15%', '25%', '25%', '10%'];
     }
 
     const allBalances = computed(() => {


### PR DESCRIPTION
## Description
Different table alignment as requested by design team

Before:
<img width="883" alt="image" src="https://user-images.githubusercontent.com/1449065/164796108-c68f0339-cc27-465b-8c05-bf491f40c128.png">

After:
<img width="860" alt="image" src="https://user-images.githubusercontent.com/1449065/164796278-edcadc6f-e27c-4b25-b398-1c9e122b03ab.png">

## Testing
See portfolio asset tale