### PR TITLE
fix: add big number to the calculation at AmountDisplay component

### DIFF
--- a/src/components/common/Price.vue
+++ b/src/components/common/Price.vue
@@ -12,7 +12,6 @@
 <script lang="ts">
 /* eslint-disable max-lines-per-function */
 import { EmerisBase } from '@emeris/types';
-import BigNumber from 'bignumber.js';
 import { computed, defineComponent, nextTick, PropType, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 
@@ -72,9 +71,7 @@ export default defineComponent({
       let value;
 
       if (props.amount.amount) {
-        value = price.value
-          ? new BigNumber(price.value * parseInt(props.amount.amount)).dividedBy(10 ** parseInt(precision))
-          : 0;
+        value = price.value ? (price.value * parseInt(props.amount.amount)) / Math.pow(10, parseInt(precision)) : 0;
       } else if (!props.showZero) {
         value = price.value;
       } else {


### PR DESCRIPTION
## Description

Add Big Number to the precision calculation at the AmountDisplay.vue component. Should show now the correct number and not: 3e-18.

Fixes: #1620 

## Testing

- Go to a wallet with a big quantity of rowan/other big precision tokens
- Check the Staked/Unstaked amounts in the asset page or in the staking table in the Portfolio page.
