### PR TITLE
fix: handle osmosis tx error result

### DIFF
--- a/src/store/demeris-api/actions/transactions.ts
+++ b/src/store/demeris-api/actions/transactions.ts
@@ -154,11 +154,18 @@ export const TransactionActions: ActionTree<APIState, RootState> & TransactionAc
         }
 
         if (data.result?.data?.value?.TxResult) {
-          return handleSuccess({ ...data.result, height: data.result.data.value.TxResult.height });
+          return handleSuccess({
+            ...data.result,
+            height: data.result.data.value.TxResult.height,
+            tx_result: data.result?.data?.value?.TxResult?.result,
+          });
         }
 
         if (data?.result?.tx_result) {
-          return handleSuccess({ ...data.result, height: data.result.height });
+          if (data.result.tx_result.code === 0) {
+            return handleSuccess({ ...data.result, height: data.result.height });
+          }
+          return handleError(new Error(data.result.tx_result.log));
         }
       };
 


### PR DESCRIPTION
## Description

Claim transactions are returning an incorrect success status.

Example response of a failed tx on osmosis:

https://api.emeris.com/v1/chain/osmosis/rpc/tx?hash=0x6E69BB7AC6151F394F16C529E577DCD33114BD269270009C00A2605A8BEB0B09

## Feature flags

VITE_FEATURE_WEBSOCKET_RESPONSE=true

## Testing

Send some transactions, including claim ones.