### PR TITLE
fix: prevent unknown denom names in dex agg

### DIFF
--- a/src/features/swap/components/Swap.vue
+++ b/src/features/swap/components/Swap.vue
@@ -101,6 +101,6 @@ const startMachine = () => {
   send('START');
 };
 
-watch([isBalancesLoaded, balances], setAllBalances, { immediate: true, deep: true });
+watch([isBalancesLoaded, balances, isSignedIn], setAllBalances, { immediate: true, deep: true });
 whenever(() => props.canStart, startMachine, { immediate: true });
 </script>

--- a/src/features/swap/components/SwapCoin/SwapCoin.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoin.vue
@@ -46,7 +46,7 @@
             class="bg-transparent text-right w-full text-text font-bold text-1 placeholder-inactive appearance-none border-none outline-none"
           />
           <span class="text-muted -text-1">
-            <Price :amount="amountToUnit({ denom, amount: value })" show-zero />
+            <Price :amount="amountToUnit({ denom: baseDenom, amount: value })" show-zero />
           </span>
         </template>
       </div>
@@ -70,6 +70,7 @@ import { useSwapActor, useSwapRefs } from '@/features/swap/state';
 import { getBaseDenomSync } from '@/utils/actionHandler';
 
 interface Props {
+  baseDenom?: string;
   chain?: string;
   chainFallback?: string;
   denom?: string;

--- a/src/features/swap/components/SwapCoin/SwapCoinInput.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoinInput.vue
@@ -3,6 +3,7 @@
     ref-key="inputAmountRef"
     :input="state.context.inputAmount"
     :denom="state.context.inputCoin?.denom"
+    :base-denom="state.context.inputCoin?.baseDenom"
     :chain="state.context.inputCoin?.chain"
     :is-loading-amount="state.matches('updating.routes.output')"
     @select="swapStore.openAssetsMenu('input')"

--- a/src/features/swap/components/SwapCoin/SwapCoinOutput.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoinOutput.vue
@@ -2,6 +2,7 @@
   <SwapCoin
     ref-key="outputAmountRef"
     :input="state.context.outputAmount"
+    :base-denom="state.context.outputCoin?.baseDenom"
     :denom="state.context.outputCoin?.denom"
     :chain="getOutputChainFromRoute(state.context)"
     :chain-fallback="resolveDisplayName(state.context?.outputCoin?.baseDenom)"

--- a/src/store/demeris-api/actions.ts
+++ b/src/store/demeris-api/actions.ts
@@ -173,8 +173,10 @@ export const actions: ActionTree<APIState, RootState> & Actions = {
         const response: AxiosResponse<EmerisAPI.VerifyTraceResponse> = await axios.get(
           getters['getEndpoint'] + '/chain/' + params.chain_name + '/denom/verify_trace/' + params.hash,
         );
-        if (response && response.data && response.data.verify_trace) {
+        if (response?.data?.verify_trace?.trace) {
           commit(MutationTypes.SET_VERIFY_TRACE, { params, value: response.data.verify_trace });
+        } else {
+          console.error('Demeris:GetVerifyTrace', response.data.verify_trace.cause);
         }
         if (subscribe) {
           commit(MutationTypes.SUBSCRIBE, { action: ActionTypes.GET_VERIFY_TRACE, payload: { params } });

--- a/src/utils/actionHandler.ts
+++ b/src/utils/actionHandler.ts
@@ -321,7 +321,7 @@ export async function ensureTraceChannel(transaction: Actions.StepTransaction) {
   let error: Error;
 
   let denoms = [];
-  const chain = typedstore.getters[GlobalGetterTypes.API.getDexChain];
+  const chain = transaction.data.chainName ?? typedstore.getters[GlobalGetterTypes.API.getDexChain];
 
   switch (transaction.type) {
     case 'addLiquidity':


### PR DESCRIPTION
## Description

Use base denom to display the price.

Also calling verify_trace for a wrong chain returns this:

https://api.emeris.com/v1/chain/cosmos-hub/denom/verify_trace/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2

So fix condition and now it will log whenever the trace was not returned.

## Feature flags

VITE_FEATURE_DEX_AGG=1

## Testing

Select denoms in osmosis chain.