### PR TITLE
fix: show below and over amount warnings

### DIFF
--- a/src/features/swap/components/SwapCoin/SwapCoinInput.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoinInput.vue
@@ -14,6 +14,12 @@
       <SwapButtonMax />
     </template>
   </SwapCoin>
+  <span v-if="state.matches('ready.invalid.belowMin')" class="text-negative">{{
+    $t('components.swap.inputBelowMin')
+  }}</span>
+  <span v-if="state.matches('ready.invalid.overMax')" class="text-negative">{{
+    $t('components.swap.inputOverMax')
+  }}</span>
 </template>
 
 <script lang="ts" setup>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -325,6 +325,7 @@
         "swapLimit": "Swap limit reached",
         "insufficentFunds": "Insufficent funds",
         "inputBelowMin": "Below Min. Amount",
+        "inputOverMax": "Over Max. Amount",
         "unAvailable": "Swap unavailable",
         "updatePrice": "Update prices",
         "review": "Review",


### PR DESCRIPTION
<img width="862" alt="image" src="https://user-images.githubusercontent.com/5869273/165902272-607ff626-33c7-4d14-96a7-d1f014a02f19.png">

Closes #1677 