### PR TITLE
fix: change-dexinfo-and-daggregation-endpoints-to-prod

### DIFF
--- a/src/components/swap/DexSwap.vue
+++ b/src/components/swap/DexSwap.vue
@@ -664,8 +664,8 @@ function setChildModalOpenStatus(payload) {
 
 async function getRoutes({ denomIn, denomOut, amountIn, amountOut, chainIn, chainOut }) {
   try {
-    //TODO: change url
-    const response = await axios.post('https://dev.demeris.io/v1' + '/daggregation/routing', {
+    const endpoint = useStore().getters[GlobalGetterTypes.API.getEndpoint];
+    const response = await axios.post(`${endpoint}/daggregation/routing`, {
       denomIn: denomIn,
       denomOut: denomOut,
       amountIn: amountIn,

--- a/src/features/swap/logic/client.ts
+++ b/src/features/swap/logic/client.ts
@@ -2,15 +2,20 @@
 import { EmerisDEXInfo } from '@emeris/types';
 import axios from 'axios';
 
+import { GlobalGetterTypes } from '@/store';
+import { useStore } from '@/utils/useStore';
+
 import { SwapContext } from '../state';
 import { amountToUnit } from './amount';
 
 export const fetchDexInfoSwaps = async (): Promise<EmerisDEXInfo.Swaps> => {
-  const { data } = await axios.get('https://api.dev.emeris.com/v1/dexinfo/swaps');
+  const endpoint = useStore().getters[GlobalGetterTypes.API.getEndpoint];
+  const { data } = await axios.get(`${endpoint}/dexinfo/swaps`);
   return data.swaps;
 };
 
 export const fetchSwapRoutes = async (context: SwapContext, direction?: string) => {
+  const endpoint = useStore().getters[GlobalGetterTypes.API.getEndpoint];
   const inputDex = context.inputCoinDex;
   if (!inputDex) throw new Error('No swaps available');
 
@@ -25,7 +30,7 @@ export const fetchSwapRoutes = async (context: SwapContext, direction?: string) 
   if (direction === 'input') payload.amountOut = null;
   if (direction === 'output') payload.amountIn = null;
 
-  const { data } = await axios.post('https://api.dev.emeris.com/v1/daggregation/routing', payload);
+  const { data } = await axios.post(`${endpoint}/daggregation/routing`, payload);
   if (data.routes?.length === 0) {
     throw new Error('No swaps available');
   }
@@ -33,7 +38,8 @@ export const fetchSwapRoutes = async (context: SwapContext, direction?: string) 
 };
 
 export const fetchAvailableDenoms = async () => {
-  const { data } = await axios.get('https://api.dev.emeris.com/v1/daggregation/available_denoms', {});
+  const endpoint = useStore().getters[GlobalGetterTypes.API.getEndpoint];
+  const { data } = await axios.get(`${endpoint}/daggregation/available_denoms`, {});
 
   return data.denoms;
 };


### PR DESCRIPTION
Endpoints are changed to prod for dexinfo and daggregation.

Please check in network tab for testing, because right now the prod endpoints are still being worked on
(daggregation endpoint might be tricky to test, because balances are broken right now)

Edit: You can actually use
`VITE_FEATURE_USE_DEV=true`
to test, if you're lucky that dev is stable