### PR TITLE
fix: enable fee validation for swap

### DIFF
--- a/src/features/swap/components/Swap.vue
+++ b/src/features/swap/components/Swap.vue
@@ -13,6 +13,7 @@
         @back="send({ type: 'STEPS.CLEAR' })"
         @close="send({ type: 'RESET' })"
         @pending="send({ type: 'RESET' })"
+        @previous="send({ type: 'STEPS.CLEAR' })"
       />
     </template>
 

--- a/src/features/transactions/components/TransactionProcessViewer/ModalFeeWarning.vue
+++ b/src/features/transactions/components/TransactionProcessViewer/ModalFeeWarning.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject } from 'vue';
+import { computed, inject, nextTick } from 'vue';
 import { useStore } from 'vuex';
 
 import AmountDisplay from '@/components/common/AmountDisplay.vue';
@@ -94,9 +94,10 @@ const goMoon = () => {
   }
 };
 
-const cancel = () => {
-  transactionsStore.removeTransaction(stepId);
+const cancel = async () => {
   emits('close');
+  await nextTick();
+  transactionsStore.removeTransaction(stepId);
 };
 const proceed = () => send('PROCEED_FEE');
 </script>

--- a/src/features/transactions/transactionProcessMachine.ts
+++ b/src/features/transactions/transactionProcessMachine.ts
@@ -372,8 +372,7 @@ export const transactionProcessMachine = createMachine<TransactionProcessContext
           context.input.steps.map((step) => feeForStep(step, context.input.gasPriceLevel)),
         );
         let validation = {};
-        // TODO: Revisit this logic once we have a better way to handle swap fees
-        if (!context.input.isDemoAccount && context.input.action !== 'swap') {
+        if (!context.input.isDemoAccount) {
           validation = await validateStepsFeeBalances(
             context.formattedSteps,
             context.input.balances,


### PR DESCRIPTION
## Description

This prevents users from initiating a transaction without sufficient funds to pay the required fees. Fixing the bug with negative values and broadcast failures.

## Feature flags

VITE_FEATURE_SWAP_WIDGET_DISABLED=false
