### PR TITLE
fix: display max / min state in button

### DIFF
--- a/src/features/swap/components/Swap.vue
+++ b/src/features/swap/components/Swap.vue
@@ -34,15 +34,7 @@
         <SwapCoinOutput />
       </div>
 
-      <Button v-if="state.matches('unavailable')" disabled>Swap unavailable</Button>
-      <Button
-        v-else
-        :status="state.matches('ready.submitting') ? 'loading' : 'active'"
-        :disabled="!state.can('SUBMIT')"
-        @click="send('SUBMIT')"
-      >
-        Swap
-      </Button>
+      <SwapButtonSwap :state="state" :send="send" />
     </div>
 
     <SwapOverlaySettings />
@@ -58,6 +50,7 @@ import { computed, nextTick, watch } from 'vue';
 import Button from '@/components/ui/Button.vue';
 import Icon from '@/components/ui/Icon.vue';
 import useAccount from '@/composables/useAccount';
+import SwapButtonSwap from '@/features/swap/components/SwapButton/SwapButtonSwap.vue';
 import { useSwapMachine, useSwapStore } from '@/features/swap/state';
 import TransactionProcessCreator from '@/features/transactions/components/TransactionProcessCreator.vue';
 import { GlobalGetterTypes } from '@/store';

--- a/src/features/swap/components/SwapButton/SwapButtonSwap.vue
+++ b/src/features/swap/components/SwapButton/SwapButtonSwap.vue
@@ -1,0 +1,38 @@
+<template>
+  <Button
+    :status="state.matches('ready.submitting') ? 'loading' : 'active'"
+    :disabled="!state.can('SUBMIT')"
+    @click="send('SUBMIT')"
+  >
+    {{ buttonName }}
+  </Button>
+</template>
+
+<script lang="ts" setup>
+import { computed, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import Button from '@/components/ui/Button.vue';
+
+interface SwapButtonProps {
+  defaultDenom: string;
+  send: any;
+  state: any;
+}
+
+const { t } = useI18n({ useScope: 'global' });
+const props = defineProps<SwapButtonProps>();
+const { send, state } = toRefs(props);
+
+const buttonName = computed(() => {
+  if (state.value.matches('unavailable')) {
+    return 'Swap unavailable';
+  } else if (state.value.matches('ready.invalid.belowMin')) {
+    return t('components.swap.inputBelowMin');
+  } else if (state.value.matches('ready.invalid.overMax')) {
+    return t('components.swap.inputOverMax');
+  } else {
+    return 'Swap';
+  }
+});
+</script>

--- a/src/features/swap/components/SwapCoin/SwapCoinInput.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoinInput.vue
@@ -14,12 +14,6 @@
       <SwapButtonMax />
     </template>
   </SwapCoin>
-  <span v-if="state.matches('ready.invalid.belowMin')" class="text-negative">{{
-    $t('components.swap.inputBelowMin')
-  }}</span>
-  <span v-if="state.matches('ready.invalid.overMax')" class="text-negative">{{
-    $t('components.swap.inputOverMax')
-  }}</span>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
## Description

Fixes: #1729 

## Feature flags

N/A

## Testing

Input an amount higher than the max amount and then try inputting 1 micro.
Observe the button text change instead of a red message displaying

---


## Screenshots (Optional)

<img width="379" alt="Screenshot 2022-04-30 at 6 21 56 PM" src="https://user-images.githubusercontent.com/31615341/166099904-04c59277-8690-4a19-b9eb-7261423fc4f9.png">
<img width="380" alt="Screenshot 2022-04-30 at 6 21 23 PM" src="https://user-images.githubusercontent.com/31615341/166099905-9162300c-cc64-46e0-9b66-5e39278faf76.png">

