### PR TITLE
fix: make a bunch of props optional to prevent warnings

### DIFF
--- a/src/components/common/TotalPrice.vue
+++ b/src/components/common/TotalPrice.vue
@@ -9,7 +9,7 @@ import CurrencyDisplay from '@/components/ui/CurrencyDisplay.vue';
 import { useTotalPortfolioBalance } from '@/composables/useTotalPortfolioBalance';
 
 interface Props {
-  smallDecimals: boolean;
+  smallDecimals?: boolean;
 }
 withDefaults(defineProps<Props>(), { smallDecimals: false });
 const displayPrice = useTotalPortfolioBalance();

--- a/src/components/stake/Apr.vue
+++ b/src/components/stake/Apr.vue
@@ -13,7 +13,7 @@ const { getStakingAPR } = useStaking();
 
 // Interfaces
 interface Props {
-  showLabel: boolean;
+  showLabel?: boolean;
   chain: string;
 }
 

--- a/src/components/stake/StakingRewardsAmountClaim.vue
+++ b/src/components/stake/StakingRewardsAmountClaim.vue
@@ -26,9 +26,9 @@ import { StakingActions } from '@/types/actions';
 
 interface Props {
   denom: string;
-  label: string;
+  label?: string;
   hasButton: boolean;
-  buttonAction: any;
+  buttonAction?: any;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/features/swap/components/SwapButton/SwapButtonSwap.vue
+++ b/src/features/swap/components/SwapButton/SwapButtonSwap.vue
@@ -15,7 +15,6 @@ import { useI18n } from 'vue-i18n';
 import Button from '@/components/ui/Button.vue';
 
 interface SwapButtonProps {
-  defaultDenom: string;
   send: any;
   state: any;
 }


### PR DESCRIPTION
## Description

Makes a bunch of props optional to prevent warnings(also removes one that was left by myself 🤦‍♂️ )

Fixes: #1735 

## Testing
Access http://localhost:8080?VITE_FEATURE_SWAP_WIDGET_DISABLED=false
after spinning up the dev env. Check console for warnings(should be none