### PR TITLE
test: fix-flakyness-send-address

### DIFF
--- a/e2e/send-subpages/send-address.spec.ts
+++ b/e2e/send-subpages/send-address.spec.ts
@@ -5,37 +5,36 @@ test.beforeEach(async ({ page }) => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
   await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
-  (await page.locator('button:has-text("Connect Keplr")')).click();
-  (await page.locator('button:has-text("Agree")')).click();
-  const navbar = await page.locator("header[role='navigation']");
-
-  (await navbar.locator('a[href="/send"]')).click();
+  page.locator('button:has-text("Connect Keplr")').click();
+  page.locator('button:has-text("Agree")').click();
 });
 
+// eslint-disable-next-line max-lines-per-function
 test.describe('Check availability of send/address subpage elements', function () {
   const recipientAddress = 'cosmos1ws4ae7ysl496j4e4pkg0yazpkf6nyrak3ptwpt';
 
   test('fill in form Recipient form', async ({ page, baseURL }) => {
+    const navbar = page.locator("header[role='navigation']");
+    navbar.locator('a[href="/send"]').click();
+
     await expect(page).toHaveURL(baseURL + '/send');
-    const sendToAddressBtn = await page
-      .locator('div[class="mt-8 pb-8 flex space-x-8"]')
-      .locator('text=Send to address');
+    const sendToAddressBtn = page.locator('div[class="mt-8 pb-8 flex space-x-8"]').locator('text=Send to address');
 
     await sendToAddressBtn.click();
     await expect(page).toHaveURL(baseURL + '/send/address');
-    const recipientHeader = await page.locator('h2').locator('text=Enter an address');
+    const recipientHeader = page.locator('h2').locator('text=Enter an address');
     await expect(recipientHeader).toBeVisible();
 
-    const recipientAddressField = await page.locator('textarea[placeholder="Recipient address"]');
+    const recipientAddressField = page.locator('textarea[placeholder="Recipient address"]');
     await expect(recipientAddressField).toBeVisible();
     await recipientAddressField.fill(recipientAddress);
 
-    const memoField = await page.locator('input[placeholder="Add reference (memo)"]');
+    const memoField = page.locator('input[placeholder="Add reference (memo)"]');
     await expect(memoField).toBeVisible();
     await memoField.fill('test memo');
 
-    const checkbox = await page.locator('input[type="checkbox"]');
-    const continueBtn = await page.locator('button:has-text("Continue")');
+    const checkbox = page.locator('input[type="checkbox"]');
+    const continueBtn = page.locator('button:has-text("Continue")');
     await expect(checkbox).toBeChecked({ checked: false });
     await expect(continueBtn).toBeDisabled();
     await checkbox.check();
@@ -43,37 +42,51 @@ test.describe('Check availability of send/address subpage elements', function ()
   });
 
   test('fill in form Amount form with Slow fee', async ({ page, baseURL }) => {
+    const atomRow = await page.locator('table.assets-table').locator('tr', { hasText: 'ATOM' });
+    await expect(atomRow).toBeVisible();
+
+    const navbar = page.locator("header[role='navigation']");
+    navbar.locator('a[href="/send"]').click();
+
     await expect(page).toHaveURL(baseURL + '/send');
-    const sendToAddressBtn = await page
-      .locator('div[class="mt-8 pb-8 flex space-x-8"]')
-      .locator('text=Send to address');
+    const sendToAddressBtn = page.locator('div[class="mt-8 pb-8 flex space-x-8"]').locator('text=Send to address');
 
     await sendToAddressBtn.click();
     await expect(page).toHaveURL(baseURL + '/send/address');
-    const recipientHeader = await page.locator('h2').locator('text=Enter an address');
+    const recipientHeader = page.locator('h2').locator('text=Enter an address');
     await expect(recipientHeader).toBeVisible();
 
-    const recipientAddressField = await page.locator('textarea[placeholder="Recipient address"]');
+    const recipientAddressField = page.locator('textarea[placeholder="Recipient address"]');
     await expect(recipientAddressField).toBeVisible();
     await recipientAddressField.fill(recipientAddress);
 
-    const memoField = await page.locator('input[placeholder="Add reference (memo)"]');
+    const memoField = page.locator('input[placeholder="Add reference (memo)"]');
     await expect(memoField).toBeVisible();
     await memoField.fill('test memo');
 
-    const checkbox = await page.locator('input[type="checkbox"]');
-    const continueBtn = await page.locator('button:has-text("Continue")');
+    const checkbox = page.locator('input[type="checkbox"]');
+    const continueBtn = page.locator('button:has-text("Continue")');
     await expect(checkbox).toBeChecked({ checked: false });
     await expect(continueBtn).toBeDisabled();
     await checkbox.check();
     await expect(continueBtn).toBeEnabled();
     await continueBtn.click();
 
-    const amountHeader = await page.locator('h2').locator('text=Enter an amount');
+    //change sendToken to ATOM
+    await page
+      .locator(
+        'button[class="bg-surface shadow-button rounded-xl overflow-hidden py-4 pl-5 pr-3 flex justify-between w-full max-w-md mx-auto outline-none text-left group focus:outline-none active:opacity-70 active:transform-none transform hover:-translate-y-px focus:-translate-y-px transition"]',
+      )
+      .click();
+    await page.locator('[placeholder="Search assets"]').click();
+    await page.locator('[placeholder="Search assets"]').fill('ATOM');
+    await page.locator('.flex.items-center.justify-between.py-4').click();
+
+    const amountHeader = page.locator('h2').locator('text=Enter an amount');
     await expect(amountHeader).toBeVisible();
-    const nextContinueBtn = await page.locator('button:has-text("Continue")');
+    const nextContinueBtn = page.locator('button:has-text("Continue")');
     await expect(nextContinueBtn).toBeDisabled();
-    const inputAmountOfAssets = await page
+    const inputAmountOfAssets = page
       .locator(
         'label[class="flexible-input relative flex items-center justify-center mx-auto w-full cursor-text text-inactive hover:text-muted uppercase"]',
       )
@@ -87,38 +100,53 @@ test.describe('Check availability of send/address subpage elements', function ()
     await nextContinueBtn.click();
   });
 
+  // eslint-disable-next-line max-lines-per-function
   test('check Review form', async ({ page, baseURL }) => {
+    const atomRow = page.locator('table.assets-table').locator('tr', { hasText: 'ATOM' });
+    await expect(atomRow).toBeVisible();
+
+    const navbar = page.locator("header[role='navigation']");
+    navbar.locator('a[href="/send"]').click();
+
     await expect(page).toHaveURL(baseURL + '/send');
-    const sendToAddressBtn = await page
-      .locator('div[class="mt-8 pb-8 flex space-x-8"]')
-      .locator('text=Send to address');
+    const sendToAddressBtn = page.locator('div[class="mt-8 pb-8 flex space-x-8"]').locator('text=Send to address');
 
     await sendToAddressBtn.click();
     await expect(page).toHaveURL(baseURL + '/send/address');
-    const recipientHeader = await page.locator('h2').locator('text=Enter an address');
+    const recipientHeader = page.locator('h2').locator('text=Enter an address');
     await expect(recipientHeader).toBeVisible();
 
-    const recipientAddressField = await page.locator('textarea[placeholder="Recipient address"]');
+    const recipientAddressField = page.locator('textarea[placeholder="Recipient address"]');
     await expect(recipientAddressField).toBeVisible();
     await recipientAddressField.fill(recipientAddress);
 
-    const memoField = await page.locator('input[placeholder="Add reference (memo)"]');
+    const memoField = page.locator('input[placeholder="Add reference (memo)"]');
     await expect(memoField).toBeVisible();
     await memoField.fill('test memo');
 
-    const checkbox = await page.locator('input[type="checkbox"]');
-    const continueBtn = await page.locator('button:has-text("Continue")');
+    const checkbox = page.locator('input[type="checkbox"]');
+    const continueBtn = page.locator('button:has-text("Continue")');
     await expect(checkbox).toBeChecked({ checked: false });
     await expect(continueBtn).toBeDisabled();
     await checkbox.check();
     await expect(continueBtn).toBeEnabled();
     await continueBtn.click();
 
-    const amountHeader = await page.locator('h2').locator('text=Enter an amount');
+    //change sendToken to ATOM
+    await page
+      .locator(
+        'button[class="bg-surface shadow-button rounded-xl overflow-hidden py-4 pl-5 pr-3 flex justify-between w-full max-w-md mx-auto outline-none text-left group focus:outline-none active:opacity-70 active:transform-none transform hover:-translate-y-px focus:-translate-y-px transition"]',
+      )
+      .click();
+    await page.locator('[placeholder="Search assets"]').click();
+    await page.locator('[placeholder="Search assets"]').fill('ATOM');
+    await page.locator('.flex.items-center.justify-between.py-4').click();
+
+    const amountHeader = page.locator('h2').locator('text=Enter an amount');
     await expect(amountHeader).toBeVisible();
-    const nextContinueBtn = await page.locator('button:has-text("Continue")');
+    const nextContinueBtn = page.locator('button:has-text("Continue")');
     await expect(nextContinueBtn).toBeDisabled();
-    const inputAmountOfAssets = await page
+    const inputAmountOfAssets = page
       .locator(
         'label[class="flexible-input relative flex items-center justify-center mx-auto w-full cursor-text text-inactive hover:text-muted uppercase"]',
       )
@@ -130,9 +158,9 @@ test.describe('Check availability of send/address subpage elements', function ()
     await expect(slowBtn).toBeVisible();
     await slowBtn.click();
     await nextContinueBtn.click();
-    const reviewHeader = await page.locator('h1:has-text("Review your transfer details")');
+    const reviewHeader = page.locator('h1:has-text("Review your transfer details")');
     await expect(reviewHeader).toBeVisible();
-    const confirmAndContinueButton = await page.locator('button:has-text("Confirm and continue")');
+    const confirmAndContinueButton = page.locator('button:has-text("Confirm and continue")');
     await expect(confirmAndContinueButton).toBeVisible();
     await expect(confirmAndContinueButton).toBeEnabled();
   });


### PR DESCRIPTION
Fixing a flaky test.

The test now first waits on the portfolio page until ATOM is present for the test account (the one you have configured in .env.local)

It now also tests the send flow by checking if you can select the atom denom - in case a different one is selected.

Should fix all flakyness this test had before