### PR TITLE
test: fix-e2e-test-back-to-atom

### DIFF
--- a/e2e/portfolio-page.spec.ts
+++ b/e2e/portfolio-page.spec.ts
@@ -20,7 +20,7 @@ test.beforeEach(async ({ page, baseURL }) => {
   await expect(page).toHaveURL(baseURL + '/');
 });
 test.describe('Portfolio visual check', function () {
-  test('visibility of elements', async ({ page /*, baseURL*/ }) => {
+  test('visibility of elements', async ({ page }) => {
     const totalBalance = await page.locator('text=Total balance');
     await expect(totalBalance).toBeVisible();
     const totalBalanceValue = await page.locator('*[class="total-price"]');


### PR DESCRIPTION
At some moment I modified this test from ATOM > CRO, because cosmos hub was down and I didn't want it to block PRs
We need a more stable fix at some moment that allows for some chains to be down.

Anyway, changing it back for now to tidy it up.

Edit:
When tidying it back up, the test broke, because there were multiple elements in the portfolio which had the text "ATOM".
This is because we were using mockdata instead of the actual data.

Because of this, I changed it back to using real data.

This means that I removed some checks for the pool information - since this is not included in the test account.