### PR TITLE
test: add-network-idle-to-welcome

### DIFF
--- a/e2e/pools.spec.ts
+++ b/e2e/pools.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page, baseURL }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
   const navbar = await page.locator("header[role='navigation']");

--- a/e2e/portfolio-page.spec.ts
+++ b/e2e/portfolio-page.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page, baseURL }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
   const navbar = await page.locator("header[role='navigation']");

--- a/e2e/receive-subpage.spec.ts
+++ b/e2e/receive-subpage.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page, baseURL }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
   const navbar = await page.locator("header[role='navigation']");

--- a/e2e/send-subpage.spec.ts
+++ b/e2e/send-subpage.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
   const navbar = await page.locator("header[role='navigation']");

--- a/e2e/send-subpages/send-move.spec.ts
+++ b/e2e/send-subpages/send-move.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
   const navbar = await page.locator("header[role='navigation']");

--- a/e2e/user-settings-dropdown.spec.ts
+++ b/e2e/user-settings-dropdown.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome'); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
 });

--- a/e2e/welcome-page.spec.ts
+++ b/e2e/welcome-page.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr=true');
   });
-  await page.goto('/welcome');
+  await page.goto('/welcome', { waitUntil: 'networkidle' });
 });
 
 test.describe('Welcome page elements location and availibility', () => {


### PR DESCRIPTION
Fabo had a hypothesis that adding `{ waitUntil: 'networkidle' }` helped against the following error in the tests:

Adding that to all other tests as well

![image](https://user-images.githubusercontent.com/1449065/167606867-8d7685f6-128c-4c7b-ba8a-130bd81714a0.png)

