### PR TITLE
test: fix-flaky-send-move-test

### DIFF
--- a/e2e/send-subpages/send-move.spec.ts
+++ b/e2e/send-subpages/send-move.spec.ts
@@ -4,16 +4,20 @@ test.beforeEach(async ({ page }) => {
   page.on('domcontentloaded', () => {
     page.evaluate('window.Cypress=true; window.chrome=true; window.keplr={}');
   });
-  await page.goto('/welcome', { waitUntil: 'networkidle' }); // TODO: Our redirects flicker the original URL before going to welcome which confuses the tests. Needs fixing on the router level
+  await page.goto('/', { waitUntil: 'networkidle' });
   (await page.locator('button:has-text("Connect Keplr")')).click();
   (await page.locator('button:has-text("Agree")')).click();
-  const navbar = await page.locator("header[role='navigation']");
-
-  (await navbar.locator('a[href="/send"]')).click();
 });
 
 test.describe('Check availability of send/move subpage elements', function () {
   test('fill in form amount form', async ({ page, baseURL }) => {
+    const atomRow = await page.locator('table.assets-table').locator('tr', { hasText: 'ATOM' });
+    await expect(atomRow).toBeVisible();
+
+    const navbar = await page.locator("header[role='navigation']");
+
+    (await navbar.locator('a[href="/send"]')).click();
+
     await expect(page).toHaveURL(baseURL + '/send');
 
     const moveBtn = await page.locator('div[class="mt-8 pb-8 flex space-x-8"]').locator('h4:has-text("Move assets")');


### PR DESCRIPTION
sometimes the send-move test breaks because assets are not properly loaded yet.

This adjustment fixes it by first waiting for ATOM to be available in the portfolio page

This fixes the TEST not being FLAKY. The actual behavior of the send flow needs to be fixed as well. It's not good that the flow breaks when some things are not loaded yet