### PR TITLE
build: increase-memory-for-build-process

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run build:production
+        run: NODE_OPTIONS="--max_old_space_size=8192" npm run build:production
 
       - name: Deploy
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run build:production
+        run: NODE_OPTIONS="--max_old_space_size=8192" npm run build:production
 
       - name: Deploy
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Build
-        run: npm run build:production
+        run: NODE_OPTIONS="--max_old_space_size=8192" npm run build:production
 
       - name: Run Playwright tests
         run: 


### PR DESCRIPTION
Increasing memory for build process so the builds to prod don't fail (and same for git deploy previews)