### PR TITLE
fix: recalculate on switch button

### DIFF
--- a/src/features/swap/logic/amount.ts
+++ b/src/features/swap/logic/amount.ts
@@ -48,7 +48,7 @@ export const getMinInputValue = () => {
 export const amountToHuman = ({ amount, denom }: EmerisBase.Amount) => {
   const precision = useStore().getters[GlobalGetterTypes.API.getDenomPrecision]({ name: getBaseDenomSync(denom) }) ?? 6;
   return {
-    amount: new BigNumber(amount).shiftedBy(-precision).decimalPlaces(precision).toString(),
+    amount: amount == '0' ? '-' : new BigNumber(amount).shiftedBy(-precision).decimalPlaces(precision).toString(),
     denom,
   };
 };

--- a/src/features/swap/state/machine.ts
+++ b/src/features/swap/state/machine.ts
@@ -383,8 +383,8 @@ export const swapMachine = createMachine<SwapContext, SwapEvents>(
             chain: undefined,
           };
         },
-        inputAmount: (_) => undefined,
-        outputAmount: (_) => undefined,
+        inputAmount: (context) => context.outputAmount,
+        outputAmount: (context) => context.inputAmount,
         inputCoin: (context) => {
           if (!context.outputCoin) return undefined;
 
@@ -439,7 +439,7 @@ export const swapMachine = createMachine<SwapContext, SwapEvents>(
       updateInputAmountFromRoute: assign({
         inputAmount: (context) => {
           if (!context.data.routes.length) {
-            return '0';
+            return '-';
           }
 
           const expectedAmount = logic.getInputAmountFromRoute(context);
@@ -449,7 +449,7 @@ export const swapMachine = createMachine<SwapContext, SwapEvents>(
       updateOutputAmountFromRoute: assign({
         outputAmount: (context) => {
           if (!context.data.routes.length) {
-            return '0';
+            return '-';
           }
           const { amount, denom } = logic.getOutputAmountFromRoute(context);
           const baseDenom = resolveBaseDenom(denom, { context });


### PR DESCRIPTION
## Description

As in issues

Fixes: #1766
Fixes: #1793 

## Feature flags

NA

## Testing

- Check if amount field shows '-' instead of 0 for unwanted states. (Atom <--> Cro may help)
- Check if switch recalculates with output denom and amount.