### PR TITLE
dont show ticker for output asset

### DIFF
--- a/src/features/swap/components/SwapCoin/SwapCoin.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoin.vue
@@ -28,7 +28,7 @@
           </div>
 
           <template v-if="isLoadingCoin || isLoadingChain">
-            <div><SkeletonLoader height="12px" width="96px" /></div>
+            <SkeletonLoader height="17px" width="96px" />
           </template>
           <span v-else-if="chain" class="text-muted -text-1 whitespace-nowrap text-left">
             <ChainName :name="chain" />
@@ -37,14 +37,15 @@
       </button>
 
       <div v-if="denom" class="flex-1 flex flex-col items-end space-y-0.5">
-        <SkeletonLoader v-if="isLoadingAmount" height="20px" width="82px" />
+        <SkeletonLoader v-if="isLoadingAmount" height="24px" width="82px" />
+        <SkeletonLoader v-if="isLoadingAmount" height="16px" width="82px" />
         <template v-else>
           <AmountInput
             ref="inputRef"
             v-model="value"
             class="bg-transparent text-right w-full text-text font-bold text-1 placeholder-inactive appearance-none border-none outline-none"
           />
-          <span v-if="value && value !== '0' && value !== '-'" class="text-muted -text-1">
+          <span v-if="showAssetPrice" class="text-muted -text-1">
             <Price :amount="amountToUnit({ denom: baseDenom, amount: value })" show-zero />
           </span>
         </template>
@@ -77,6 +78,7 @@ interface Props {
   isLoadingAmount?: boolean;
   isLoadingChain?: boolean;
   refKey: string;
+  type?: string;
 }
 
 const props = defineProps<Props>();
@@ -94,5 +96,13 @@ const value = computed<string>({
   set(value) {
     emit('update:input', value);
   },
+});
+
+const showAssetPrice = computed(() => {
+  if (props?.type === 'output') {
+    return value.value && value.value !== '0' && value.value !== '-';
+  } else {
+    return true;
+  }
 });
 </script>

--- a/src/features/swap/components/SwapCoin/SwapCoinOutput.vue
+++ b/src/features/swap/components/SwapCoin/SwapCoinOutput.vue
@@ -7,6 +7,7 @@
     :chain="getOutputChainFromRoute(state.context)"
     :is-loading-chain="state.matches('updating.routes')"
     :is-loading-amount="state.matches('updating.routes.input')"
+    type="output"
     @select="swapStore.openAssetsMenu('output')"
     @update:input="send({ type: 'OUTPUT.CHANGE_AMOUNT', value: $event })"
   >


### PR DESCRIPTION
## Description

removing ticker as discussed [here](https://allinbits.slack.com/archives/C02AXJ0K9F1/p1652360469887699?thread_ts=1652359828.392989&cid=C02AXJ0K9F1)

also adds a skeleton loader for price. compare with prod.

Fixes: #1795 

## Feature flags

NA

## Testing
shows nothing under juno until route is fetched
<img width="142" alt="Screenshot 2022-05-13 at 6 59 32 AM" src="https://user-images.githubusercontent.com/12444344/168193396-141e36bd-2f1e-4eb9-8717-9f258e2a2f5a.png">

