### PR TITLE
fix: refresh account balances whenever a tx is confirmed

### DIFF
--- a/src/features/swap/state/machine.ts
+++ b/src/features/swap/state/machine.ts
@@ -290,6 +290,9 @@ export const swapMachine = createMachine<SwapContext, SwapEvents>(
             target: '#ready',
             actions: 'clearSteps',
           },
+          'BALANCES.SET': {
+            actions: 'assignBalances',
+          },
         },
       },
     },

--- a/src/features/transactions/transactionProcessMachine.ts
+++ b/src/features/transactions/transactionProcessMachine.ts
@@ -289,7 +289,7 @@ export const transactionProcessMachine = createMachine<TransactionProcessContext
       },
       next: {
         id: 'next',
-        entry: { type: 'logEvent', key: 'completed_tx' },
+        entry: [{ type: 'logEvent', key: 'completed_tx' }, 'refreshBalances'],
         always: [
           { target: 'receipt', cond: 'hasMoreTransactions' },
           { target: 'receipt', cond: 'hasMoreSteps' },
@@ -701,6 +701,9 @@ export const transactionProcessMachine = createMachine<TransactionProcessContext
         }
 
         event(key, data);
+      },
+      refreshBalances: () => {
+        useStore().dispatch(GlobalActionTypes.API.GET_ALL_BALANCES, { subscribe: false });
       },
     },
 

--- a/src/store/demeris-api/actions/balances.ts
+++ b/src/store/demeris-api/actions/balances.ts
@@ -33,7 +33,7 @@ export interface BalanceActionsInterface {
     context: APIActionContext,
     payload: Subscribable<ActionParams<EmerisAPI.AddrReq>>,
   ): Promise<EmerisAPI.UnbondingDelegations>;
-  [ActionTypes.GET_ALL_BALANCES](context: APIActionContext): Promise<EmerisAPI.Balances>;
+  [ActionTypes.GET_ALL_BALANCES](context: APIActionContext, payload?: Subscribable<any>): Promise<EmerisAPI.Balances>;
   [ActionTypes.GET_ALL_STAKING_BALANCES](context: APIActionContext): Promise<EmerisAPI.StakingBalances>;
   [ActionTypes.GET_ALL_UNBONDING_DELEGATIONS](context: APIActionContext): Promise<EmerisAPI.UnbondingDelegations>;
 }
@@ -142,7 +142,7 @@ export const BalanceActions: ActionTree<APIState, RootState> & BalanceActionsInt
       return getters['getBalances'](params);
     }
   },
-  async [ActionTypes.GET_ALL_BALANCES]({ dispatch, getters, rootGetters }) {
+  async [ActionTypes.GET_ALL_BALANCES]({ dispatch, getters, rootGetters }, params) {
     try {
       const keyHashes = rootGetters[GlobalGetterTypes.USER.getKeyhashes];
 
@@ -165,7 +165,9 @@ export const BalanceActions: ActionTree<APIState, RootState> & BalanceActionsInt
         }
       }
       for (const keyHash of keyHashes) {
-        balanceLoads.push(dispatch(ActionTypes.GET_BALANCES, { subscribe: true, params: { address: keyHash } }));
+        balanceLoads.push(
+          dispatch(ActionTypes.GET_BALANCES, { subscribe: params?.subscribe ?? true, params: { address: keyHash } }),
+        );
       }
       await Promise.all(balanceLoads);
       if (rootGetters[GlobalGetterTypes.USER.getBalancesFirstLoad]) {


### PR DESCRIPTION
## Description

Original thread: https://allinbits.slack.com/archives/C02AXJ0K9F1/p1652459599620349

## Feature flags

N/A

## Testing

Make some transactions and verify that the balances are updating as expected.
