### PR TITLE
fix/dynamic-imports

### DIFF
--- a/src/components/ui/Icon.vue
+++ b/src/components/ui/Icon.vue
@@ -26,7 +26,6 @@ export default defineComponent({
     const currentIcon = shallowRef('');
     const isReady = ref(false);
     onMounted(async () => {
-      //console.log('bc')
       const icon = await defineAsyncComponent(() => import(`@/components/common/Icons/${props.name}.vue`));
       currentIcon.value = icon;
       isReady.value = true;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default () => {
       chunkSizeWarningLimit: 1000,
       sourcemap: true,
     },
-    plugins: [vue(), nodeResolve(), dynamicImport(), envCompatible(), eslintPlugin({ fix: true }), dynamicImport()],
+    plugins: [vue(), nodeResolve(), dynamicImport(), envCompatible(), eslintPlugin({ fix: true })],
     resolve: {
       alias: {
         '@starport/vuex': path.resolve(__dirname, './src/utils/EmerisError.ts'),


### PR DESCRIPTION
## Description

An attempt tp fix.. failed to fetch dynamic imported module error...

Fixes: #1715

## Feature flags

NA

## Testing

I tested using npm run preview + npm run build:production to reproduce the error.

## Additional details

Edit: I can't seem to reproduce the error in the prod branch now :/ 

Also, I'm hitting FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory a lot while building

was checking if the alias was an issue because for vite, alias doesn't work well with dynamic imports..
switching to draft because needs more looking into.